### PR TITLE
trigger web workflow once the core has a new commit merged into master

### DIFF
--- a/.github/workflows/basic-check.yml
+++ b/.github/workflows/basic-check.yml
@@ -1,4 +1,4 @@
-name: beam-studio-core-ci
+name: basic-check
 
 on:
   push:

--- a/.github/workflows/repository-dispatch.yml
+++ b/.github/workflows/repository-dispatch.yml
@@ -1,0 +1,20 @@
+name: repository-dispatch
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  trigger-web:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Dispatch an event to trigger web's workflow
+        run: |
+          curl \
+            -X POST \
+            -u "${{secrets.TRIGGER_WEB_USERNAME}}:${{secrets.TRIGGER_WEB_TOKEN}}" \
+            -H "Accept: application/vnd.github.v3+json" \
+            https://api.github.com/repos/flux3dp/beam-studio-web/dispatches \
+            -d '{"event_type":"core_merged"}'


### PR DESCRIPTION
Once there is a new merge into master, it will fire an event called **core_merged** that is listened by the web workflow which will run e2e tests and make auto deployment. Therefore ideally we can ensure any changes in core are supposed not to break any e2e tests.