### PR TITLE
merge unit test with coverage check

### DIFF
--- a/.github/workflows/basic-check.yml
+++ b/.github/workflows/basic-check.yml
@@ -7,25 +7,9 @@ on:
   pull_request:
 
 jobs:
-  unit-test:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        node-version: [12.19]
-        python-version: [3.7]
-        os: [macOS-latest, windows-latest]
-    steps:
-      - uses: actions/checkout@v2
-      - name: Install dependencies
-        run: yarn install
-      - name: Run unit tests
-        run: yarn run spec
-  coverage:
-    needs: unit-test
+  unit-tests-and-coverage:
     runs-on: ubuntu-latest
     if: github.ref != 'refs/heads/master'
-    env:
-      CI_JOB_NUMBER: 1
     steps:
       - uses: actions/checkout@v2
       - uses: artiomtr/jest-coverage-report-action@v1.3
@@ -40,7 +24,7 @@ jobs:
       - name: Eslint check
         uses: reviewdog/action-eslint@v1
   web-e2e:
-    needs: [coverage, eslint-check]
+    needs: [unit-tests-and-coverage, eslint-check]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
originally, `unit-test` and `coverage` these two jobs would cover duplicate task which is to ensure all unit tests get passed. So now, merge them together in order to save CI execution time.