### PR TITLE
Fix tutorial of Ador

### DIFF
--- a/src/web/app/components/beambox/top-bar/TopBar.tsx
+++ b/src/web/app/components/beambox/top-bar/TopBar.tsx
@@ -23,6 +23,8 @@ import SelectMachineButton from 'app/components/beambox/top-bar/SelectMachineBut
 import showResizeAlert from 'helpers/device/fit-device-workarea-alert';
 import storage from 'implementations/storage';
 import TopBarHints from 'app/components/beambox/top-bar/TopBarHints';
+import tutorialConstants from 'app/constants/tutorial-constants';
+import tutorialController from 'app/views/tutorials/tutorialController';
 import { CanvasContext } from 'app/contexts/CanvasContext';
 import { getSVGAsync } from 'helpers/svg-editor-helper';
 import { IDeviceInfo } from 'interfaces/IDevice';
@@ -153,7 +155,12 @@ export default class TopBar extends React.PureComponent<Record<string, never>, S
       }
       $(workarea).css('cursor', 'url(img/camera-cursor.svg), cell');
       if (constant.adorModels.includes(device.model)) {
-        PreviewModeController.previewFullWorkarea(() => updateTopBar());
+        PreviewModeController.previewFullWorkarea(() => {
+          updateTopBar();
+          if (tutorialController.getNextStepRequirement() === tutorialConstants.PREVIEW_PLATFORM) {
+            tutorialController.handleNextStep();
+          }
+        });
       }
       setIsPreviewing(true);
       if (startPreviewCallback) {

--- a/src/web/app/constants/tutorial-constants.tsx
+++ b/src/web/app/constants/tutorial-constants.tsx
@@ -175,18 +175,24 @@ const NEW_USER_TUTORIAL: ITutorial = {
       dialogBoxStyles: {
         position: {
           right: calculateRight(4, RightRef.RIGHT_PANEL),
-          top: calculateTop(141, TopRef.LAYER_LIST),
+          get top(): number {
+            return calculateTop(60, TopRef.LAYER_PARAMS);
+          },
         },
         arrowDirection: 'right',
       },
       holePosition: {
         right: calculateRight(50, RightRef.RIGHT_SROLL_BAR),
-        top: calculateTop(126, TopRef.LAYER_LIST),
+        get top(): number {
+          return calculateTop(45, TopRef.LAYER_PARAMS);
+        },
       },
       holeSize: { width: rightPanelInnerWidth - 60, height: 30 },
       hintCircle: {
         right: calculateRight(50, RightRef.RIGHT_SROLL_BAR),
-        top: calculateTop(122, TopRef.LAYER_LIST),
+        get top(): number {
+          return calculateTop(40, TopRef.LAYER_PARAMS);
+        },
         width: rightPanelInnerWidth - 55,
         height: 40,
       },
@@ -308,18 +314,24 @@ const NEW_USER_TUTORIAL: ITutorial = {
       dialogBoxStyles: {
         position: {
           right: calculateRight(4, RightRef.RIGHT_PANEL),
-          top: calculateTop(141, TopRef.LAYER_LIST),
+          get top(): number {
+            return calculateTop(60, TopRef.LAYER_PARAMS);
+          },
         },
         arrowDirection: 'right',
       },
       holePosition: {
         right: calculateRight(50, RightRef.RIGHT_SROLL_BAR),
-        top: calculateTop(126, TopRef.LAYER_LIST),
+        get top(): number {
+          return calculateTop(45, TopRef.LAYER_PARAMS);
+        },
       },
       holeSize: { width: rightPanelInnerWidth - 60, height: 30 },
       hintCircle: {
         right: calculateRight(50, RightRef.RIGHT_SROLL_BAR),
-        top: calculateTop(122, TopRef.LAYER_LIST),
+        get top(): number {
+          return calculateTop(40, TopRef.LAYER_PARAMS);
+        },
         width: rightPanelInnerWidth - 55,
         height: 40,
       },
@@ -367,11 +379,18 @@ const INTERFACE_TUTORIAL: ITutorial = {
     },
     {
       dialogBoxStyles: {
-        position: { right: isMacOrWeb ? 220 : 240, top: calculateTop(10, TopRef.TOPBAR) },
+        position: {
+          get right(): number {
+            return calculateRight(170, RightRef.PATH_PREVIEW_BTN);
+          },
+          top: calculateTop(10, TopRef.TOPBAR),
+        },
         arrowDirection: 'top',
       },
       hintCircle: {
-        right: isMacOrWeb ? 130 : 144,
+        get right(): number {
+          return calculateRight(80, RightRef.PATH_PREVIEW_BTN);
+        },
         top: calculateTop(2),
         width: 180,
         height: 36,
@@ -380,30 +399,39 @@ const INTERFACE_TUTORIAL: ITutorial = {
     },
     {
       dialogBoxStyles: {
-        position: { right: isMacOrWeb ? 105 : 125, top: calculateTop(10, TopRef.TOPBAR) },
+        position: {
+          get right(): number {
+            return calculateRight(58, RightRef.PATH_PREVIEW_BTN);
+          },
+          top: calculateTop(10, TopRef.TOPBAR),
+        },
         arrowDirection: 'top',
       },
       hintCircle: {
-        right: isMacOrWeb ? 89 : 107,
+        get right(): number {
+          return calculateRight(42, RightRef.PATH_PREVIEW_BTN);
+        },
         top: calculateTop(2),
         width: 36,
         height: 36,
       },
       text: i18n.lang.topbar.frame_task,
     },
-    {
-      dialogBoxStyles: {
-        position: { right: isMacOrWeb ? 66 : 85, top: calculateTop(10, TopRef.TOPBAR) },
-        arrowDirection: 'top',
-      },
-      hintCircle: {
-        right: isMacOrWeb ? 49 : 65,
-        top: calculateTop(2),
-        width: 36,
-        height: 36,
-      },
-      text: i18n.lang.topbar.task_preview,
-    },
+    // Will be invisible with Ador
+    // Rocover when path preview is ready for Ador
+    // {
+    //   dialogBoxStyles: {
+    //     position: { right: isMacOrWeb ? 66 : 85, top: calculateTop(10, TopRef.TOPBAR) },
+    //     arrowDirection: 'top',
+    //   },
+    //   hintCircle: {
+    //     right: isMacOrWeb ? 49 : 65,
+    //     top: calculateTop(2),
+    //     width: 36,
+    //     height: 36,
+    //   },
+    //   text: i18n.lang.topbar.task_preview,
+    // },
     {
       dialogBoxStyles: {
         position: { right: 24, top: calculateTop(10, TopRef.TOPBAR) },
@@ -453,6 +481,7 @@ const INTERFACE_TUTORIAL: ITutorial = {
         height: 40,
       },
       text: LANG.newInterface.pen_tool,
+      callback: TutorialCallbacks.SCROLL_TO_ADD_LAYER,
     },
     {
       dialogBoxStyles: {

--- a/src/web/app/views/dialogs/__snapshots__/NonStopProgress.spec.tsx.snap
+++ b/src/web/app/views/dialogs/__snapshots__/NonStopProgress.spec.tsx.snap
@@ -51,7 +51,6 @@ exports[`test NonStopProgress should render correctly 1`] = `
             >
               <button
                 class="ant-btn css-dev-only-do-not-override-hash ant-btn-default"
-                style="display: none;"
                 type="button"
               >
                 <span>

--- a/src/web/app/views/tutorials/TutorialContext.tsx
+++ b/src/web/app/views/tutorials/TutorialContext.tsx
@@ -1,9 +1,7 @@
 import React from 'react';
 
-import beamboxPreference from 'app/actions/beambox/beambox-preference';
 import eventEmitterFactory from 'helpers/eventEmitterFactory';
 import { getSVGAsync } from 'helpers/svg-editor-helper';
-import { modelsWithModules } from 'app/constants/layer-module/layer-modules';
 import { ITutorialDialog } from 'interfaces/ITutorial';
 import { TutorialCallbacks } from 'app/constants/tutorial-constants';
 
@@ -42,9 +40,10 @@ export class TutorialContextProvider extends React.Component<Props, States> {
     this.clearDefaultRect();
   }
 
-  handleCallback = (callbackId: TutorialCallbacks): void => {
+  handleCallback = async (callbackId: TutorialCallbacks): Promise<void> => {
     if (callbackId === TutorialCallbacks.SELECT_DEFAULT_RECT) this.selectDefaultRect();
-    else if (callbackId === TutorialCallbacks.SCROLL_TO_PARAMETER) this.scrollToParameterSelect();
+    else if (callbackId === TutorialCallbacks.SCROLL_TO_PARAMETER)
+      await this.scrollToParameterSelect();
     else if (callbackId === TutorialCallbacks.SCROLL_TO_ADD_LAYER) this.scrollToAddLayerButton();
     else console.log('Unknown callback id', callbackId);
   };
@@ -71,17 +70,10 @@ export class TutorialContextProvider extends React.Component<Props, States> {
     svgCanvas.selectOnly([defaultRect], true);
   };
 
-  scrollToParameterSelect = (): void => {
-    const workarea = beamboxPreference.read('workarea');
-    if (!modelsWithModules.includes(workarea)) return;
-    const scroll = () => {
-      if (document.querySelector('#laser-panel').clientHeight > 0) {
-        // height of module block
-        document.querySelector('#sidepanels').scrollTop = 106;
-      } else setTimeout(scroll, 30);
-    };
-    scroll();
-  }
+  scrollToParameterSelect = async (): Promise<void> => {
+    await new Promise<void>((resolve) => setTimeout(resolve, 100));
+    document.querySelector('.layerparams').scrollIntoView();
+  };
 
   scrollToAddLayerButton = (): void => {
     document.querySelector('#sidepanels').scrollTop = 0;
@@ -94,12 +86,12 @@ export class TutorialContextProvider extends React.Component<Props, States> {
     }
   };
 
-  handleNextStep = () => {
+  handleNextStep = async () => {
     const { currentStep } = this.state;
     const { dialogStylesAndContents, onClose } = this.props;
     if (dialogStylesAndContents[currentStep].callback) {
       console.log(dialogStylesAndContents[currentStep].callback);
-      this.handleCallback(dialogStylesAndContents[currentStep].callback as TutorialCallbacks);
+      await this.handleCallback(dialogStylesAndContents[currentStep].callback as TutorialCallbacks);
     }
     if (currentStep + 1 < dialogStylesAndContents.length) {
       this.setState({ currentStep: currentStep + 1 });

--- a/src/web/app/views/tutorials/TutorialContext.tsx
+++ b/src/web/app/views/tutorials/TutorialContext.tsx
@@ -86,7 +86,7 @@ export class TutorialContextProvider extends React.Component<Props, States> {
     }
   };
 
-  handleNextStep = async () => {
+  handleNextStep = async (): Promise<void> => {
     const { currentStep } = this.state;
     const { dialogStylesAndContents, onClose } = this.props;
     if (dialogStylesAndContents[currentStep].callback) {

--- a/src/web/helpers/absolute-position-helper.spec.ts
+++ b/src/web/helpers/absolute-position-helper.spec.ts
@@ -35,9 +35,10 @@ describe('test calculateTop', () => {
   });
 
   test('TopRef.LAYER_PARAMS', () => {
-    jest.spyOn(document, 'querySelector').mockImplementation(() => {
-      return { getBoundingClientRect: jest.fn().mockReturnValueOnce({ top: 300 }) } as any;
-    });
+    jest.spyOn(document, 'querySelector').mockImplementation(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      () => ({ getBoundingClientRect: jest.fn().mockReturnValueOnce({ top: 300 }) } as any)
+    );
     const result = calculateTop(10, TopRef.LAYER_PARAMS);
     expect(result).toEqual(310);
   });

--- a/src/web/helpers/absolute-position-helper.spec.ts
+++ b/src/web/helpers/absolute-position-helper.spec.ts
@@ -10,6 +10,14 @@ jest.mock('app/actions/beambox/constant', () => ({
   rightPanelWidth: 50,
 }));
 
+const mockBeamboxPreferenceRead = jest.fn();
+jest.mock('app/actions/beambox/beambox-preference', () => ({
+  read: (...args) => mockBeamboxPreferenceRead(...args),
+}));
+
+const mockIsDev = jest.fn();
+jest.mock('helpers/is-dev', () => () => mockIsDev());
+
 describe('test calculateTop', () => {
   test('TopRef.WINDOW', () => {
     const result = calculateTop(10);
@@ -24,6 +32,14 @@ describe('test calculateTop', () => {
   test('TopRef.LAYER_LIST', () => {
     const result = calculateTop(10, TopRef.LAYER_LIST);
     expect(result).toEqual(40);
+  });
+
+  test('TopRef.LAYER_PARAMS', () => {
+    jest.spyOn(document, 'querySelector').mockImplementation(() => {
+      return { getBoundingClientRect: jest.fn().mockReturnValueOnce({ top: 300 }) } as any;
+    });
+    const result = calculateTop(10, TopRef.LAYER_PARAMS);
+    expect(result).toEqual(310);
   });
 });
 
@@ -41,5 +57,17 @@ describe('test calculateRight', () => {
   test('RightRef.RIGHT_PANEL', () => {
     const result = calculateRight(10, RightRef.RIGHT_PANEL);
     expect(result).toEqual(60);
+  });
+
+  test('RightRef.PATH_PREVIEW_BTN with beamo', () => {
+    mockBeamboxPreferenceRead.mockReturnValue('fbm1');
+    const result = calculateRight(10, RightRef.PATH_PREVIEW_BTN);
+    expect(result).toEqual(78);
+  });
+
+  test('RightRef.PATH_PREVIEW_BTN with Ador', () => {
+    mockBeamboxPreferenceRead.mockReturnValue('ado1');
+    const result = calculateRight(10, RightRef.PATH_PREVIEW_BTN);
+    expect(result).toEqual(36);
   });
 });

--- a/src/web/helpers/absolute-position-helper.ts
+++ b/src/web/helpers/absolute-position-helper.ts
@@ -1,16 +1,23 @@
+import beamboxPreference from 'app/actions/beambox/beambox-preference';
 import Constant from 'app/actions/beambox/constant';
+import isDev from 'helpers/is-dev';
+import { modelsWithModules } from 'app/constants/layer-module/layer-modules';
 
 export enum TopRef {
   WINDOW = 0,
   TOPBAR = 1,
   LAYER_LIST = 2,
+  LAYER_PARAMS = 3,
 }
 
 export enum RightRef {
   WINDOW = 0,
   RIGHT_SROLL_BAR = 1,
   RIGHT_PANEL = 2,
+  PATH_PREVIEW_BTN = 3,
 }
+
+const isMacOrWeb = window.os === 'MacOS' || window.FLUX.version === 'web';
 
 export const calculateTop = (top: number, ref: TopRef = TopRef.WINDOW): number => {
   switch (ref) {
@@ -18,6 +25,9 @@ export const calculateTop = (top: number, ref: TopRef = TopRef.WINDOW): number =
       return top + Constant.topBarHeight;
     case TopRef.LAYER_LIST:
       return top + Constant.topBarHeight + Constant.layerListHeight;
+    case TopRef.LAYER_PARAMS:
+      const offset = document.querySelector('.layerparams').getBoundingClientRect().top;
+      return top + offset;
     default:
       return top + Constant.menuberHeight;
   }
@@ -29,6 +39,11 @@ export const calculateRight = (right: number, ref: RightRef = RightRef.WINDOW): 
       return right + Constant.rightPanelScrollBarWidth;
     case RightRef.RIGHT_PANEL:
       return right + Constant.rightPanelWidth;
+    case RightRef.PATH_PREVIEW_BTN:
+      const workarea = beamboxPreference.read('workarea');
+      const shouldHideBtn = !isDev() && modelsWithModules.includes(workarea);
+      const offset = (isMacOrWeb ? 6 : 26) + (shouldHideBtn ? 0 : 42);
+      return right + offset;
     default:
       return right;
   }

--- a/src/web/helpers/absolute-position-helper.ts
+++ b/src/web/helpers/absolute-position-helper.ts
@@ -25,9 +25,10 @@ export const calculateTop = (top: number, ref: TopRef = TopRef.WINDOW): number =
       return top + Constant.topBarHeight;
     case TopRef.LAYER_LIST:
       return top + Constant.topBarHeight + Constant.layerListHeight;
-    case TopRef.LAYER_PARAMS:
+    case TopRef.LAYER_PARAMS: {
       const offset = document.querySelector('.layerparams').getBoundingClientRect().top;
       return top + offset;
+    }
     default:
       return top + Constant.menuberHeight;
   }
@@ -39,11 +40,12 @@ export const calculateRight = (right: number, ref: RightRef = RightRef.WINDOW): 
       return right + Constant.rightPanelScrollBarWidth;
     case RightRef.RIGHT_PANEL:
       return right + Constant.rightPanelWidth;
-    case RightRef.PATH_PREVIEW_BTN:
+    case RightRef.PATH_PREVIEW_BTN: {
       const workarea = beamboxPreference.read('workarea');
       const shouldHideBtn = !isDev() && modelsWithModules.includes(workarea);
       const offset = (isMacOrWeb ? 6 : 26) + (shouldHideBtn ? 0 : 42);
       return right + offset;
+    }
     default:
       return right;
   }


### PR DESCRIPTION
1. Auto start camera preview without clicks
2. Topbar right buttons position without path preview button
3. Hide path preview button tutorial
4. Scroll right panel and change box/dialog position of preset selector according to window height