### PR TITLE
Add insecure websocket

### DIFF
--- a/src/web/app/actions/beambox/beambox-init.ts
+++ b/src/web/app/actions/beambox/beambox-init.ts
@@ -19,6 +19,7 @@ import FontConstants from 'app/constants/font-constants';
 import fontHelper from 'helpers/fonts/fontHelper';
 import getDevice from 'helpers/device/get-device';
 import i18n from 'helpers/i18n';
+import isWeb from 'helpers/is-web';
 import MessageCaller, { MessageLevel } from 'app/actions/message-caller';
 import menu from 'implementations/menu';
 import ratingHelper from 'helpers/rating-helper';
@@ -93,7 +94,7 @@ class BeamboxInit {
     const isNewUser = !!storage.get('new-user');
     const defaultFontConvert = BeamboxPreference.read('font-convert');
     const hasMachineConnection = checkConnection();
-    if (window.FLUX.version === 'web' && navigator.maxTouchPoints >= 1) {
+    if (isWeb() && navigator.maxTouchPoints >= 1) {
       const res = await fluxId.getPreference('did_gesture_tutorial', true);
       if (res && !res.error) {
         if (res.status === 'ok' && !res.value) {
@@ -109,7 +110,7 @@ class BeamboxInit {
         }
       }
     }
-    await this.showFirstCalibrationDialog()
+    await this.showFirstCalibrationDialog();
     if (hasMachineConnection && !isMobile()) {
       await this.showTutorial(isNewUser);
     }
@@ -197,13 +198,13 @@ class BeamboxInit {
 
   private initDefaultFont(): void {
     const lang = navigator.language;
-    const isWeb = window.FLUX.version === 'web';
+    const web = isWeb();
     const { os } = window;
     let defaultFontFamily = 'Arial';
-    if (isWeb) defaultFontFamily = 'Noto Sans';
+    if (web) defaultFontFamily = 'Noto Sans';
     else if (os === 'Linux') defaultFontFamily = 'Ubuntu';
     if (FontConstants[lang]) {
-      if (isWeb && FontConstants[lang].web) {
+      if (web && FontConstants[lang].web) {
         defaultFontFamily = FontConstants[lang].web;
       } else if (FontConstants[lang][os]) {
         defaultFontFamily = FontConstants[lang][os];
@@ -250,14 +251,14 @@ class BeamboxInit {
     const hasDoneFirstCali = AlertConfig.read('done-first-cali');
     let hasMachineConnection = checkConnection();
     // in web, wait for websocket connection
-    if (window.FLUX.version === 'web' && !hasDoneFirstCali && !hasMachineConnection) {
+    const web = isWeb();
+    if (web && !hasDoneFirstCali && !hasMachineConnection) {
       await new Promise((r) => setTimeout(r, 1000));
       hasMachineConnection = checkConnection();
     }
-    const shouldShow =
-      window.FLUX.version === 'web'
-        ? hasMachineConnection && !hasDoneFirstCali
-        : isNewUser || !hasDoneFirstCali;
+    const shouldShow = web
+      ? hasMachineConnection && !hasDoneFirstCali
+      : isNewUser || !hasDoneFirstCali;
     let caliRes = true;
     if (shouldShow) {
       const res = await this.askFirstTimeCameraCalibration();

--- a/src/web/app/actions/beambox/constant.ts
+++ b/src/web/app/actions/beambox/constant.ts
@@ -1,4 +1,5 @@
 import isDev from 'helpers/is-dev';
+import isWeb from 'helpers/is-web';
 
 export const modelsSupportUsb = new Set(['fhexa1', 'ado1']);
 
@@ -65,10 +66,10 @@ export default {
   rightPanelWidth: window.os !== 'MacOS' ? 258 : 242, // px
   rightPanelScrollBarWidth: window.os !== 'MacOS' ? 16 : 0, // px
   sidePanelsWidth: window.os !== 'MacOS' ? 308 : 292, // px
-  topBarHeight: window.os === 'Windows' && window.FLUX.version !== 'web' ? 70 : 40, // px
+  topBarHeight: window.os === 'Windows' && !isWeb() ? 70 : 40, // px
   topBarHeightWithoutTitleBar: 40, // px
-  titlebarHeight: window.os === 'Windows' && window.FLUX.version !== 'web' ? 30 : 0, // px
-  menuberHeight: window.os === 'Windows' && window.FLUX.version !== 'web' ? 30 : 40, // px
+  titlebarHeight: window.os === 'Windows' && !isWeb() ? 30 : 0, // px
+  menuberHeight: window.os === 'Windows' && !isWeb() ? 30 : 40, // px
   layerListHeight: 400, // px
   rulerWidth: 15, // px
   rotaryYRatio: {

--- a/src/web/app/actions/beambox/menuActions.ts
+++ b/src/web/app/actions/beambox/menuActions.ts
@@ -11,6 +11,7 @@ import ExportFuncs from 'app/actions/beambox/export-funcs';
 import FileExportHelper from 'helpers/file-export-helper';
 import FnWrapper from 'app/actions/beambox/svgeditor-function-wrapper';
 import i18n from 'helpers/i18n';
+import isWeb from 'helpers/is-web';
 import imageEdit from 'helpers/image-edit';
 import MessageCaller, { MessageLevel } from 'app/actions/message-caller';
 import OutputError from 'helpers/output-error';
@@ -69,7 +70,7 @@ const loadExampleFile = async (path: string) => {
   const oReq = new XMLHttpRequest();
   oReq.open(
     'GET',
-    window.FLUX.version === 'web' ? `https://beam-studio-web.s3.ap-northeast-1.amazonaws.com/${path}` : path,
+    isWeb() ? `https://beam-studio-web.s3.ap-northeast-1.amazonaws.com/${path}` : path,
     true
   );
   oReq.responseType = 'blob';
@@ -122,9 +123,8 @@ export default {
   EXPORT_PNG: () => FileExportHelper.exportAsImage('png'),
   EXPORT_JPG: () => FileExportHelper.exportAsImage('jpg'),
   EXPORT_FLUX_TASK: (): void => {
-    ExportFuncs.exportFcode();
-    // if (window.FLUX.version === 'web') Dialog.forceLoginWrapper(() => ExportFuncs.exportFcode());
-    // else ExportFuncs.exportFcode();
+    if (isWeb()) Dialog.forceLoginWrapper(() => ExportFuncs.exportFcode());
+    else ExportFuncs.exportFcode();
   },
   UNDO: () => svgEditor.clickUndo(),
   REDO: () => svgEditor.clickRedo(),

--- a/src/web/app/actions/beambox/svg-editor.ts
+++ b/src/web/app/actions/beambox/svg-editor.ts
@@ -55,6 +55,7 @@ import storage from 'implementations/storage';
 import pdfHelper from 'implementations/pdfHelper';
 import Shortcuts from 'helpers/shortcuts';
 import i18n from 'helpers/i18n';
+import isWeb from 'helpers/is-web';
 import SvgLaserParser from 'helpers/api/svg-laser-parser';
 import eventEmitterFactory from 'helpers/eventEmitterFactory';
 import { IFont } from 'interfaces/IFont';
@@ -334,7 +335,7 @@ const svgEditor = window['svgEditor'] = (function () {
       },
       text: {
         stroke_width: 1,
-        font_size: window.FLUX.version === 'web' ? 200 : 100,
+        font_size: isWeb() ? 200 : 100,
         font_family: defaultFont ? defaultFont.family : 'Arial',
         font_postscriptName: defaultFont ? defaultFont.postscriptName : 'ArialMT',
         fill: '#fff',

--- a/src/web/app/actions/dialog-caller.tsx
+++ b/src/web/app/actions/dialog-caller.tsx
@@ -14,6 +14,7 @@ import FluxCredit from 'app/components/dialogs/FluxCredit';
 import FluxIdLogin from 'app/components/dialogs/FluxIdLogin';
 import FluxPlusWarning from 'app/components/dialogs/FluxPlusWarning';
 import i18n from 'helpers/i18n';
+import isWeb from 'helpers/is-web';
 import InputLightBox from 'app/widgets/InputLightbox';
 import LayerColorConfigPanel from 'app/views/beambox/Layer-Color-Config';
 import MediaTutorial from 'app/components/dialogs/MediaTutorial';
@@ -78,7 +79,7 @@ const getPromptId = (): string => {
 
 const showLoginDialog = (callback?: () => void, silent = false): void => {
   if (isIdExist('flux-id-login')) return;
-  if (window.FLUX.version === 'web' && callback) {
+  if (isWeb() && callback) {
     window.addEventListener('DISMISS_FLUX_LOGIN', callback);
   }
   addDialogComponent(

--- a/src/web/app/components/beambox/path-preview/PathPreview.tsx
+++ b/src/web/app/components/beambox/path-preview/PathPreview.tsx
@@ -18,6 +18,7 @@ import eventEmitterFactory from 'helpers/eventEmitterFactory';
 import exportFuncs from 'app/actions/beambox/export-funcs';
 import getDevice from 'helpers/device/get-device';
 import i18n from 'helpers/i18n';
+import isWeb from 'helpers/is-web';
 import Pointable from 'app/components/beambox/path-preview/Pointable';
 import progressCaller from 'app/actions/progress-caller';
 import SidePanel from 'app/components/beambox/path-preview/SidePanel';
@@ -1732,11 +1733,7 @@ class PathPreview extends React.Component<Props, State> {
           rapidDist={`${Math.round(this.gcodePreview.g0DistReal)} mm`}
           currentPosition={this.renderPosition()}
           isStartHereEnabled={playState !== PlayState.PLAY}
-          handleStartHere={
-            window.FLUX.version === 'web'
-              ? () => dialogCaller.forceLoginWrapper(this.handleStartHere)
-              : this.handleStartHere
-          }
+          handleStartHere={isWeb() ? () => dialogCaller.forceLoginWrapper(this.handleStartHere) : this.handleStartHere}
           togglePathPreview={togglePathPreview}
         />
       </div>

--- a/src/web/app/components/beambox/path-preview/SidePanel.tsx
+++ b/src/web/app/components/beambox/path-preview/SidePanel.tsx
@@ -1,7 +1,8 @@
 import classNames from 'classnames';
-import React from 'react';
+import React, { useMemo } from 'react';
 
 import i18n from 'helpers/i18n';
+import isWeb from 'helpers/is-web';
 
 interface Props {
   size: string;
@@ -36,10 +37,14 @@ function SidePanel({
     </div>
   );
 
-  const sideClass = classNames({
-    short: window.os === 'Windows' && window.FLUX.version !== 'web',
-    wide: window.os !== 'MacOS',
-  });
+  const sideClass = useMemo(
+    () =>
+      classNames({
+        short: window.os === 'Windows' && !isWeb(),
+        wide: window.os !== 'MacOS',
+      }),
+    []
+  );
 
   return (
     <div id="path-preview-side-panel" className={sideClass}>
@@ -53,9 +58,7 @@ function SidePanel({
         {renderDataBlock(LANG.rapid_distance, rapidDist)}
         {renderDataBlock(LANG.current_position, currentPosition)}
       </div>
-      <div className="remark">
-        {LANG.remark}
-      </div>
+      <div className="remark">{LANG.remark}</div>
       <div className="buttons">
         <div
           className={classNames('btn btn-default primary', { disabled: !isStartHereEnabled })}

--- a/src/web/app/components/beambox/right-panel/RightPanel.tsx
+++ b/src/web/app/components/beambox/right-panel/RightPanel.tsx
@@ -2,6 +2,7 @@ import React, { memo, useCallback, useContext, useEffect, useRef, useState } fro
 import classNames from 'classnames';
 
 import eventEmitterFactory from 'helpers/eventEmitterFactory';
+import isWeb from 'helpers/is-web';
 import LayerPanel from 'app/components/beambox/right-panel/LayerPanel';
 import ObjectPanel from 'app/views/beambox/Right-Panels/ObjectPanel';
 import ObjectPanelItem from 'app/views/beambox/Right-Panels/ObjectPanelItem';
@@ -79,7 +80,7 @@ const RightPanel = (): JSX.Element => {
   }, [panelType, isPathEditing]);
 
   const sideClass = classNames(styles.sidepanels, {
-    [styles.short]: window.os === 'Windows' && window.FLUX.version !== 'web',
+    [styles.short]: window.os === 'Windows' && !isWeb(),
     [styles.wide]: window.os !== 'MacOS',
   });
   return (

--- a/src/web/app/components/beambox/top-bar/GoButton.tsx
+++ b/src/web/app/components/beambox/top-bar/GoButton.tsx
@@ -14,6 +14,7 @@ import Dialog from 'app/actions/dialog-caller';
 import ExportFuncs from 'app/actions/beambox/export-funcs';
 import getDevice from 'helpers/device/get-device';
 import isDev from 'helpers/is-dev';
+import isWeb from 'helpers/is-web';
 import LayerModules, { modelsWithModules } from 'app/constants/layer-module/layer-modules';
 import SymbolMaker from 'helpers/symbol-maker';
 import storage from 'implementations/storage';
@@ -276,7 +277,7 @@ const GoButton = (props: Props): JSX.Element => {
       exportTask(device);
     };
 
-    if (window.FLUX.version === 'web' && navigator.language !== 'da')
+    if (isWeb() && navigator.language !== 'da')
       Dialog.forceLoginWrapper(handleExport);
     else handleExport();
   };

--- a/src/web/app/components/beambox/top-bar/PathPreviewButton.tsx
+++ b/src/web/app/components/beambox/top-bar/PathPreviewButton.tsx
@@ -4,6 +4,7 @@ import React, { useContext } from 'react';
 import checkWebGL from 'helpers/check-webgl';
 import constant from 'app/actions/beambox/constant';
 import isDev from 'helpers/is-dev';
+import isWeb from 'helpers/is-web';
 import TopBarIcons from 'app/icons/top-bar/TopBarIcons';
 import useI18n from 'helpers/useI18n';
 import useWorkarea from 'helpers/hooks/useWorkarea';
@@ -44,7 +45,7 @@ function PathPreviewButton({
   };
   const className = classNames(styles.button, {
     [styles.highlighted]: isPathPreviewing,
-    [styles.disabled]: isPreviewing || (!isDeviceConnected && window.FLUX.version === 'web'),
+    [styles.disabled]: isPreviewing || (!isDeviceConnected && isWeb()),
   });
   return (
     <div

--- a/src/web/app/components/beambox/top-bar/TopBar.tsx
+++ b/src/web/app/components/beambox/top-bar/TopBar.tsx
@@ -14,6 +14,7 @@ import FrameButton from 'app/components/beambox/top-bar/FrameButton';
 import getDevice from 'helpers/device/get-device';
 import GoButton from 'app/components/beambox/top-bar/GoButton';
 import i18n from 'helpers/i18n';
+import isWeb from 'helpers/is-web';
 import Menu from 'app/components/beambox/top-bar/Menu';
 import ObjectPanelController from 'app/views/beambox/Right-Panels/contexts/ObjectPanelController';
 import PathPreviewButton from 'app/components/beambox/top-bar/PathPreviewButton';
@@ -42,7 +43,7 @@ getSVGAsync((globalSVG) => {
 
 const { $ } = window;
 const LANG = i18n.lang.topbar;
-const isWhiteTopBar = window.os !== 'MacOS' && window.FLUX.version !== 'web';
+const isWhiteTopBar = window.os !== 'MacOS' && !isWeb();
 
 interface State {
   hasDiscoverdMachine: boolean;
@@ -198,7 +199,7 @@ export default class TopBar extends React.PureComponent<Record<string, never>, S
 
   // eslint-disable-next-line class-methods-use-this
   renderMenu(): JSX.Element {
-    if (window.FLUX.version === 'web') {
+    if (isWeb()) {
       const { currentUser } = this.context;
       return (
         <div className={classNames('top-bar-menu-container', styles.menu)}>
@@ -239,7 +240,7 @@ export default class TopBar extends React.PureComponent<Record<string, never>, S
         {this.renderHint()}
         {this.renderMenu()}
         <CommonTools
-          isWeb={window.FLUX.version === 'web'}
+          isWeb={isWeb()}
           hide={isPreviewing || isPathPreviewing}
         />
       </div>

--- a/src/web/app/components/boxgen/Boxgen.tsx
+++ b/src/web/app/components/boxgen/Boxgen.tsx
@@ -1,9 +1,10 @@
 import classNames from 'classnames';
-import React from 'react';
+import React, { useMemo } from 'react';
 import { Button } from 'antd';
 
 import constant from 'app/actions/beambox/constant';
 import FloatingPanel from 'app/widgets/FloatingPanel';
+import isWeb from 'helpers/is-web';
 import TopBarIcons from 'app/icons/top-bar/TopBarIcons';
 import useI18n from 'helpers/useI18n';
 import { BoxgenProvider } from 'app/contexts/BoxgenContext';
@@ -19,6 +20,7 @@ import styles from './Boxgen.module.scss';
 const Boxgen = ({ onClose }: { onClose?: () => void }): JSX.Element => {
   const lang = useI18n().boxgen;
   const isMobile = useIsMobile();
+  const web = useMemo(() => isWeb(), []);
 
   return (
     <BoxgenProvider onClose={onClose}>
@@ -26,7 +28,7 @@ const Boxgen = ({ onClose }: { onClose?: () => void }): JSX.Element => {
         <FloatingPanel
           className={classNames(styles.boxgen, {
             [styles.windows]: window.os === 'Windows',
-            [styles.desktop]: window.FLUX.version !== 'web',
+            [styles.desktop]: !web,
           })}
           anchors={[0, window.innerHeight - constant.titlebarHeight]}
           title={lang.title}
@@ -50,7 +52,7 @@ const Boxgen = ({ onClose }: { onClose?: () => void }): JSX.Element => {
         <div
           className={classNames(styles.boxgen, {
             [styles.windows]: window.os === 'Windows',
-            [styles.desktop]: window.FLUX.version !== 'web',
+            [styles.desktop]: !web,
           })}
         >
           <div className={styles.sider}>

--- a/src/web/app/components/dialogs/ChangeLog.tsx
+++ b/src/web/app/components/dialogs/ChangeLog.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import browser from 'implementations/browser';
 import changelog from 'implementations/changelog';
 import i18n from 'helpers/i18n';
+import isWeb from 'helpers/is-web';
 import { Button, Modal } from 'antd';
 
 const LANG = i18n.lang.change_logs;
@@ -40,7 +41,7 @@ function ChangeLog({ onClose }: Props): JSX.Element {
 
   const renderVersion = () => {
     const { version } = window.FLUX;
-    if (version === 'web') return null;
+    if (isWeb()) return null;
     return (
       <div className="app">
         {`📖 Beam Studio ${version.replace('-', ' ')} `}

--- a/src/web/app/constants/tutorial-constants.tsx
+++ b/src/web/app/constants/tutorial-constants.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import browser from 'implementations/browser';
 import Constant from 'app/actions/beambox/constant';
 import i18n from 'helpers/i18n';
+import isWeb from 'helpers/is-web';
 import { ITutorial } from 'interfaces/ITutorial';
 import {
   TopRef, RightRef, calculateTop, calculateRight,
@@ -33,7 +34,7 @@ const nextStepRequirements = {
   SEND_FILE: 'SEND_FILE',
 };
 
-const isMacOrWeb = window.os === 'MacOS' || window.FLUX.version === 'web';
+const isMacOrWeb = window.os === 'MacOS' || isWeb();
 const rightPanelInnerWidth = Constant.rightPanelWidth - Constant.rightPanelScrollBarWidth;
 
 const adjustFocusLinkClick = () => {

--- a/src/web/app/contexts/DialogContext.tsx
+++ b/src/web/app/contexts/DialogContext.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 
 import eventEmitterFactory from 'helpers/eventEmitterFactory';
+import isWeb from 'helpers/is-web';
 
 export const DialogContext = React.createContext({
   dialogComponents: [],
@@ -24,7 +25,7 @@ export class DialogContextProvider extends React.Component<any> {
     eventEmitter.on('CLEAR_ALL_DIALOG_COMPONENTS', this.clearAllDialogComponents.bind(this));
     eventEmitter.on('CHECK_ID_EXIST', this.isIdExist.bind(this));
     eventEmitter.on('POP_DIALOG_BY_ID', this.popDialogById.bind(this));
-    if (window.FLUX.version === 'web') {
+    if (isWeb()) {
       window.addEventListener('DISMISS_FLUX_LOGIN', () => {
         this.popDialogById.call(this, 'flux-id-login');
       });

--- a/src/web/app/lang/da.ts
+++ b/src/web/app/lang/da.ts
@@ -1764,6 +1764,12 @@ const lang: ILang = {
     download_success: 'Kameradata er downloadet succesfuldt.',
     upload_success: 'Kameradata er uploadet succesfuldt.',
   },
+  insecure_websocket: {
+    extension_detected: 'Beam Studio Connect-udvidelse fundet',
+    extension_detected_description: "Vi har registreret, at du har installeret Beam Studio Connect-udvidelsen. Klik venligst på 'Bekræft' for at omdirigere til HTTPS, eller klik på 'Annuller' for at fortsætte med at bruge HTTP.",
+    extension_not_deteced: 'Kan ikke registrere Beam Studio Connect-udvidelse',
+    extension_not_deteced_description: "For at bruge HTTPS skal du klikke på 'Bekræft' for at installere Beam Studio Connect-udvidelsen, eller klikke på 'Annuller' for at omdirigere til HTTP.",
+  },
 };
 
 export default lang;

--- a/src/web/app/lang/de.ts
+++ b/src/web/app/lang/de.ts
@@ -1767,6 +1767,12 @@ const lang: ILang = {
     download_success: 'Kameradaten erfolgreich heruntergeladen.',
     upload_success: 'Kameradaten erfolgreich hochgeladen.',
   },
+  insecure_websocket: {
+    extension_detected: 'Beam Studio Connect-Erweiterung erkannt',
+    extension_detected_description: "Wir haben festgestellt, dass Sie die Beam Studio Connect-Erweiterung installiert haben. Bitte klicken Sie auf 'Bestätige', um zu HTTPS umzuleiten, oder klicken Sie auf 'Abbrechen', um weiterhin HTTP zu verwenden.",
+    extension_not_deteced: 'Beam Studio Connect-Erweiterung konnte nicht erkannt werden',
+    extension_not_deteced_description: "Um HTTPS zu verwenden, klicken Sie bitte auf 'Bestätige', um die Beam Studio Connect-Erweiterung zu installieren, oder klicken Sie auf 'Abbrechen', um zu HTTP umzuleiten.",
+  },
 };
 
 export default lang;

--- a/src/web/app/lang/el.ts
+++ b/src/web/app/lang/el.ts
@@ -1764,6 +1764,12 @@ const lang: ILang = {
     download_success: 'Επιτυχής λήψη δεδομένων κάμερας.',
     upload_success: 'Επιτυχής αποστολή δεδομένων κάμερας.',
   },
+  insecure_websocket: {
+    extension_detected: 'Εντοπίστηκε η επέκταση Beam Studio Connect',
+    extension_detected_description: 'Ανιχνεύσαμε ότι έχετε εγκαταστήσει την επέκταση Beam Studio Connect. Κάντε κλικ στο "Επιβεβαίωση" για να ανακατευθυνθείτε στο HTTPS, ή κάντε κλικ στο "Ακύρωση" για να συνεχίσετε να χρησιμοποιείτε το HTTP.',
+    extension_not_deteced: 'Δεν ήταν δυνατή η ανίχνευση της επέκτασης Beam Studio Connect',
+    extension_not_deteced_description: 'Για να χρησιμοποιήσετε το HTTPS, πατήστε "Επιβεβαίωση" για να εγκαταστήσετε την επέκταση Beam Studio Connect, ή πατήστε "Ακύρωση" για να ανακατευθυνθείτε στο HTTP.',
+  },
 };
 
 export default lang;

--- a/src/web/app/lang/en.ts
+++ b/src/web/app/lang/en.ts
@@ -1767,6 +1767,12 @@ const lang: ILang = {
     download_success: 'Successfully downloaded camera data.',
     upload_success: 'Successfully uploaded camera data.',
   },
+  insecure_websocket: {
+    extension_detected: 'Beam Studio Connect Extension Detected',
+    extension_detected_description: 'We have detected that you have installed the Beam Studio Connect extension. Please click ‘Confirm’ to redirect to HTTPS, or click ‘Cancel’ to continue using HTTP.',
+    extension_not_deteced: 'Unable to Detect Beam Studio Connect Extension',
+    extension_not_deteced_description: 'To use HTTPS, please click ‘Confirm’ to install the Beam Studio Connect extension, or click ‘Cancel’ to redirect to HTTP.',
+  },
 };
 
 export default lang;

--- a/src/web/app/lang/es.ts
+++ b/src/web/app/lang/es.ts
@@ -1767,6 +1767,12 @@ const lang: ILang = {
     download_success: 'Datos de la cámara descargados con éxito.',
     upload_success: 'Datos de la cámara cargados con éxito.',
   },
+  insecure_websocket: {
+    extension_detected: 'Extensión Beam Studio Connect detectada',
+    extension_detected_description: "Hemos detectado que has instalado la extensión Beam Studio Connect. Haz clic en 'Confirmar' para redirigir a HTTPS, o haz clic en 'Cancelar' para seguir utilizando HTTP.",
+    extension_not_deteced: 'No se pudo detectar la extensión Beam Studio Connect',
+    extension_not_deteced_description: "Para usar HTTPS, haz clic en 'Confirmar' para instalar la extensión Beam Studio Connect, o haz clic en 'Cancelar' para redirigir a HTTP.",
+  },
 };
 
 export default lang;

--- a/src/web/app/lang/fi.ts
+++ b/src/web/app/lang/fi.ts
@@ -1764,6 +1764,12 @@ const lang: ILang = {
     download_success: 'Kameran tiedot on ladattu onnistuneesti.',
     upload_success: 'Kameran tiedot on ladattu onnistuneesti.',
   },
+  insecure_websocket: {
+    extension_detected: 'Havaittu Beam Studio Connect -laajennus',
+    extension_detected_description: "Olemme havainneet, että olet asentanut Beam Studio Connect -laajennuksen. Napsauta 'Vahvista' ohjataksesi HTTPS:ään tai napsauta 'Peruuta' jatkaaksesi HTTP:n käyttöä.",
+    extension_not_deteced: 'Beam Studio Connect -laajennusta ei voitu havaita',
+    extension_not_deteced_description: "Käyttääksesi HTTPS:ää napsauta 'Vahvista' asentaaksesi Beam Studio Connect -laajennuksen tai napsauta 'Peruuta' ohjataksesi HTTP:hen.",
+  },
 };
 
 export default lang;

--- a/src/web/app/lang/fr.ts
+++ b/src/web/app/lang/fr.ts
@@ -1764,6 +1764,12 @@ const lang: ILang = {
     download_success: 'Données de la caméra téléchargées avec succès.',
     upload_success: 'Données de la caméra téléchargées avec succès.',
   },
+  insecure_websocket: {
+    extension_detected: 'Extension Beam Studio Connect détectée',
+    extension_detected_description: "Nous avons détecté que vous avez installé l'extension Beam Studio Connect. Veuillez cliquer sur 'Confirmer' pour rediriger vers HTTPS, ou cliquez sur 'Annuler' pour continuer à utiliser HTTP.",
+    extension_not_deteced: "Impossible de détecter l'extension Beam Studio Connect",
+    extension_not_deteced_description: "Pour utiliser HTTPS, veuillez cliquer sur 'Confirmer' pour installer l'extension Beam Studio Connect, ou cliquez sur 'Annuler' pour rediriger vers HTTP.",
+  },
 };
 
 export default lang;

--- a/src/web/app/lang/id.ts
+++ b/src/web/app/lang/id.ts
@@ -1764,6 +1764,12 @@ const lang: ILang = {
     download_success: 'Data kamera berhasil diunduh.',
     upload_success: 'Data kamera berhasil diunggah.',
   },
+  insecure_websocket: {
+    extension_detected: 'Perpanjangan Beam Studio Connect Terdeteksi',
+    extension_detected_description: "Kami telah mendeteksi bahwa Anda telah menginstal perpanjangan Beam Studio Connect. Klik 'Konfirmasi' untuk mengalihkan ke HTTPS, atau klik 'Batal' untuk melanjutkan menggunakan HTTP.",
+    extension_not_deteced: 'Tidak dapat Mendeteksi Perpanjangan Beam Studio Connect',
+    extension_not_deteced_description: "Untuk menggunakan HTTPS, klik 'Konfirmasi' untuk menginstal perpanjangan Beam Studio Connect, atau klik 'Batal' untuk mengalihkan ke HTTP.",
+  },
 };
 
 export default lang;

--- a/src/web/app/lang/it.ts
+++ b/src/web/app/lang/it.ts
@@ -1764,6 +1764,12 @@ const lang: ILang = {
     download_success: 'Dati della fotocamera scaricati con successo.',
     upload_success: 'Dati della fotocamera caricati con successo.',
   },
+  insecure_websocket: {
+    extension_detected: "Rilevata l'estensione Beam Studio Connect",
+    extension_detected_description: "Abbiamo rilevato che hai installato l'estensione Beam Studio Connect. Fare clic su 'Conferma' per reindirizzare a HTTPS, o fare clic su 'Annulla' per continuare a utilizzare HTTP.",
+    extension_not_deteced: "Impossibile rilevare l'estensione Beam Studio Connect",
+    extension_not_deteced_description: "Per utilizzare HTTPS, fare clic su 'Conferma' per installare l'estensione Beam Studio Connect, o fare clic su 'Annulla' per reindirizzare a HTTP.",
+  },
 };
 
 export default lang;

--- a/src/web/app/lang/ja.ts
+++ b/src/web/app/lang/ja.ts
@@ -1767,6 +1767,12 @@ const lang: ILang = {
     download_success: 'カメラデータのダウンロードに成功しました。',
     upload_success: 'カメラデータのアップロードに成功しました。',
   },
+  insecure_websocket: {
+    extension_detected: 'Beam Studio Connect 拡張機能が検出されました',
+    extension_detected_description: 'Beam Studio Connect 拡張機能がインストールされていることが検出されました。HTTPS にリダイレクトするには「確認」をクリックするか、HTTP を継続するには「キャンセル」をクリックしてください。',
+    extension_not_deteced: 'Beam Studio Connect 拡張機能を検出できません',
+    extension_not_deteced_description: 'HTTPS を使用するには、Beam Studio Connect 拡張機能をインストールするには「確認」をクリックするか、HTTP にリダイレクトするには「キャンセル」をクリックしてください。',
+  },
 };
 
 export default lang;

--- a/src/web/app/lang/kr.ts
+++ b/src/web/app/lang/kr.ts
@@ -1767,6 +1767,12 @@ const lang: ILang = {
     download_success: '카메라 데이터 다운로드에 성공했습니다.',
     upload_success: '카메라 데이터 업로드에 성공했습니다.',
   },
+  insecure_websocket: {
+    extension_detected: 'Beam Studio Connect 확장 프로그램이 감지되었습니다',
+    extension_detected_description: "Beam Studio Connect 확장 프로그램이 설치되어 있음을 감지했습니다. HTTPS로 리디렉션하려면 '확인'을 클릭하거나 HTTP를 계속 사용하려면 '취소'를 클릭하십시오.",
+    extension_not_deteced: 'Beam Studio Connect 확장 프로그램을 감지할 수 없습니다',
+    extension_not_deteced_description: "HTTPS를 사용하려면 Beam Studio Connect 확장 프로그램을 설치하려면 '확인'을 클릭하거나 HTTP로 리디렉션하려면 '취소'를 클릭하십시오.",
+  },
 };
 
 export default lang;

--- a/src/web/app/lang/ms.ts
+++ b/src/web/app/lang/ms.ts
@@ -1764,6 +1764,12 @@ const lang: ILang = {
     download_success: 'Data kamera berjaya dimuat turun.',
     upload_success: 'Data kamera berjaya dimuat naik.',
   },
+  insecure_websocket: {
+    extension_detected: 'Pengesanan Sambungan Beam Studio Connect',
+    extension_detected_description: 'Kami telah mengesan anda telah memasang sambungan Beam Studio Connect. Sila klik ‘Sahkan’ untuk diarahkan ke HTTPS, atau klik ‘Batal’ untuk terus menggunakan HTTP.',
+    extension_not_deteced: 'Tidak dapat Mengesan Sambungan Beam Studio Connect',
+    extension_not_deteced_description: 'Untuk menggunakan HTTPS, sila klik ‘Sahkan’ untuk memasang sambungan Beam Studio Connect, atau klik ‘Batal’ untuk diarahkan ke HTTP.',
+  },
 };
 
 export default lang;

--- a/src/web/app/lang/nl.ts
+++ b/src/web/app/lang/nl.ts
@@ -1764,6 +1764,12 @@ const lang: ILang = {
     download_success: 'Camera-gegevens succesvol gedownload.',
     upload_success: 'Camera-gegevens succesvol geüpload.',
   },
+  insecure_websocket: {
+    extension_detected: 'Beam Studio Connect-extensie gedetecteerd',
+    extension_detected_description: "We hebben gedetecteerd dat u de Beam Studio Connect-extensie heeft geïnstalleerd. Klik op 'Bevestigen' om door te verwijzen naar HTTPS, of klik op 'Annuleren' om HTTP te blijven gebruiken.",
+    extension_not_deteced: 'Kan Beam Studio Connect-extensie niet detecteren',
+    extension_not_deteced_description: "Om HTTPS te gebruiken, klik op 'Bevestigen' om de Beam Studio Connect-extensie te installeren, of klik op 'Annuleren' om door te verwijzen naar HTTP.",
+  },
 };
 
 export default lang;

--- a/src/web/app/lang/no.ts
+++ b/src/web/app/lang/no.ts
@@ -1764,6 +1764,12 @@ switch_to_layer_panel: 'Bytt til lagpanel',
     download_success: 'Kameradata er lastet ned.',
     upload_success: 'Kameradata er lastet opp.',
   },
+  insecure_websocket: {
+    extension_detected: 'Beam Studio Connect-utvidelsen er oppdaget',
+    extension_detected_description: "Vi har oppdaget at du har installert Beam Studio Connect-utvidelsen. Klik på 'Bekreft' for å omdirigere til HTTPS, eller klikk på 'Avbryt' for å fortsette å bruke HTTP.",
+    extension_not_deteced: 'Kunne ikke oppdage Beam Studio Connect-utvidelsen',
+    extension_not_deteced_description: "For å bruke HTTPS, klikk på 'Bekreft' for å installere Beam Studio Connect-utvidelsen, eller klikk på 'Avbryt' for å omdirigere til HTTP.",
+  },
 };
 
 export default lang;

--- a/src/web/app/lang/pl.ts
+++ b/src/web/app/lang/pl.ts
@@ -1767,6 +1767,12 @@ const lang: ILang = {
     download_success: 'Pomyślnie pobrano dane z kamery.',
     upload_success: 'Pomyślnie przesłano dane z kamery.',
   },
+  insecure_websocket: {
+    extension_detected: 'Wykryto rozszerzenie Beam Studio Connect',
+    extension_detected_description: 'Wykryliśmy, że zainstalowałeś rozszerzenie Beam Studio Connect. Kliknij "Potwierdź", aby przekierować do protokołu HTTPS, lub kliknij "Anuluj", aby kontynuować korzystanie z protokołu HTTP.',
+    extension_not_deteced: 'Nie można wykryć rozszerzenia Beam Studio Connect',
+    extension_not_deteced_description: 'Aby używać protokołu HTTPS, kliknij "Potwierdź", aby zainstalować rozszerzenie Beam Studio Connect, lub kliknij "Anuluj", aby przekierować do protokołu HTTP.',
+  },
 };
 
 export default lang;

--- a/src/web/app/lang/pt.ts
+++ b/src/web/app/lang/pt.ts
@@ -1764,6 +1764,12 @@ const lang: ILang = {
     download_success: 'Dados da câmera baixados com sucesso.',
     upload_success: 'Dados da câmera enviados com sucesso.',
   },
+  insecure_websocket: {
+    extension_detected: 'Extensão Beam Studio Connect detectada',
+    extension_detected_description: "Detectamos que você instalou a extensão Beam Studio Connect. Clique em 'Confirmar' para redirecionar para HTTPS, ou clique em 'Cancelar' para continuar usando HTTP.",
+    extension_not_deteced: 'Não foi possível detectar a extensão Beam Studio Connect',
+    extension_not_deteced_description: "Para usar HTTPS, clique em 'Confirmar' para instalar a extensão Beam Studio Connect, ou clique em 'Cancelar' para redirecionar para HTTP.",
+  },
 };
 
 export default lang;

--- a/src/web/app/lang/se.ts
+++ b/src/web/app/lang/se.ts
@@ -1764,6 +1764,12 @@ switch_to_layer_panel: 'Byt till lagerpanelen',
     download_success: 'Kameradata har laddats ner framgångsrikt.',
     upload_success: 'Kameradata har laddats upp framgångsrikt.',
   },
+  insecure_websocket: {
+    extension_detected: 'Beam Studio Connect-tillägg upptäckt',
+    extension_detected_description: "Vi har upptäckt att du har installerat Beam Studio Connect-tillägget. Klicka på 'Bekräfta' för att omdirigera till HTTPS, eller klicka på 'Avbryt' för att fortsätta använda HTTP.",
+    extension_not_deteced: 'Kunde inte upptäcka Beam Studio Connect-tillägg',
+    extension_not_deteced_description: "För att använda HTTPS, klicka på 'Bekräfta' för att installera Beam Studio Connect-tillägget, eller klicka på 'Avbryt' för att omdirigera till HTTP.",
+  },
 };
 
 export default lang;

--- a/src/web/app/lang/th.ts
+++ b/src/web/app/lang/th.ts
@@ -1764,6 +1764,12 @@ const lang: ILang = {
     download_success: 'ดาวน์โหลดข้อมูลกล้องสำเร็จ',
     upload_success: 'อัปโหลดข้อมูลกล้องสำเร็จ',
   },
+  insecure_websocket: {
+    extension_detected: 'ตรวจพบส่วนขยาย Beam Studio Connect',
+    extension_detected_description: "เราตรวจพบว่าคุณได้ติดตั้งส่วนขยาย Beam Studio Connect กรุณาคลิก 'ยืนยัน' เพื่อเปลี่ยนเส้นทางไปที่ HTTPS หรือคลิก 'ยกเลิก' เพื่อทำต่อตาม HTTP",
+    extension_not_deteced: 'ไม่สามารถตรวจพบส่วนขยาย Beam Studio Connect',
+    extension_not_deteced_description: "เพื่อใช้ HTTPS กรุณาคลิก 'ยืนยัน' เพื่อติดตั้งส่วนขยาย Beam Studio Connect หรือคลิก 'ยกเลิก' เพื่อเปลี่ยนเส้นทางไปที่ HTTP",
+  },
 };
 
 export default lang;

--- a/src/web/app/lang/vi.ts
+++ b/src/web/app/lang/vi.ts
@@ -1764,6 +1764,12 @@ const lang: ILang = {
     download_success: 'Dữ liệu máy ảnh đã được tải xuống thành công.',
     upload_success: 'Dữ liệu máy ảnh đã được tải lên thành công.',
   },
+  insecure_websocket: {
+    extension_detected: 'Phát hiện Phần mở rộng Beam Studio Connect',
+    extension_detected_description: "Chúng tôi đã phát hiện bạn đã cài đặt phần mở rộng Beam Studio Connect. Nhấn vào 'Xác nhận' để chuyển hướng đến HTTPS, hoặc nhấn vào 'Hủy' để tiếp tục sử dụng HTTP.",
+    extension_not_deteced: 'Không thể phát hiện Phần mở rộng Beam Studio Connect',
+    extension_not_deteced_description: "Để sử dụng HTTPS, hãy nhấn vào 'Xác nhận' để cài đặt Phần mở rộng Beam Studio Connect, hoặc nhấn vào 'Hủy' để chuyển hướng đến HTTP.",
+  },
 };
 
 export default lang;

--- a/src/web/app/lang/zh-cn.ts
+++ b/src/web/app/lang/zh-cn.ts
@@ -1767,6 +1767,12 @@ const lang: ILang = {
     download_success: '相机数据下载成功。',
     upload_success: '相机数据上传成功。',
   },
+  insecure_websocket: {
+    extension_detected: '检测到 Beam Studio Connect 扩展',
+    extension_detected_description: '我们检测到您已安装了 Beam Studio Connect 扩展。请点击“确认”以重定向到 HTTPS，或点击“取消”以继续使用 HTTP。',
+    extension_not_deteced: '无法检测到 Beam Studio Connect 扩展',
+    extension_not_deteced_description: '若要使用 HTTPS，请点击“确认”以安装 Beam Studio Connect 扩展，或点击“取消”以重定向到 HTTP。',
+  },
 };
 
 export default lang;

--- a/src/web/app/lang/zh-tw.ts
+++ b/src/web/app/lang/zh-tw.ts
@@ -1767,6 +1767,12 @@ const lang: ILang = {
     download_success: '相機數據下載成功。',
     upload_success: '相機數據上傳成功。',
   },
+  insecure_websocket: {
+    extension_detected: '偵測到 Beam Studio Connect 擴充功能',
+    extension_detected_description: '我們偵測到您已安裝了 Beam Studio Connect 擴充功能。請按下「確認」重新導向至 HTTPS，或者選擇「取消」以繼續使用目前的 HTTP 網址。',
+    extension_not_deteced: '無法偵測到 Beam Studio Connect 擴充功能',
+    extension_not_deteced_description: '若要使用 HTTPS，請按下「確認」以前往安裝 Beam Studio Connect 擴充功能，或按下「取消」以導向至 HTTP。',
+  },
 };
 
 export default lang;

--- a/src/web/app/pages/ConnectMachineIp.tsx
+++ b/src/web/app/pages/ConnectMachineIp.tsx
@@ -12,6 +12,7 @@ import checkSoftwareForAdor from 'helpers/check-software';
 import constant from 'app/actions/beambox/constant';
 import Discover from 'helpers/api/discover';
 import dialogCaller from 'app/actions/dialog-caller';
+import isWeb from 'helpers/is-web';
 import menuDeviceActions from 'app/actions/beambox/menuDeviceActions';
 import network from 'implementations/network';
 import storage from 'implementations/storage';
@@ -95,7 +96,7 @@ const ConnectMachineIp = (): JSX.Element => {
   };
 
   const setUpLocalStorageIp = (ip: string) => {
-    if (window.FLUX.version === 'web') {
+    if (isWeb()) {
       localStorage.setItem('host', ip);
       localStorage.setItem('port', '8000');
     }
@@ -114,7 +115,7 @@ const ConnectMachineIp = (): JSX.Element => {
           const device = discoveredDevicesRef.current.find((d) => testingIps.includes(d.ipaddr));
           if (device) {
             if (
-              window.FLUX.version === 'web' &&
+              isWeb() &&
               !versionChecker(device.version).meetRequirement('LATEST_GHOST_FOR_WEB')
             ) {
               alertCaller.popUp({

--- a/src/web/app/pages/Settings.tsx
+++ b/src/web/app/pages/Settings.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/explicit-module-boundary-types */
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import * as React from 'react';
+import React from 'react';
 import classNames from 'classnames';
 
 import AdorModule from 'app/components/settings/AdorModule';
@@ -15,6 +15,7 @@ import Engraving from 'app/components/settings/Engraving';
 import Experimental from 'app/components/settings/Experimental';
 import General from 'app/components/settings/General';
 import i18n from 'helpers/i18n';
+import isWeb from 'helpers/is-web';
 import layerModuleHelper from 'helpers/layer-module/layer-module-helper';
 import Mask from 'app/components/settings/Mask';
 import Module from 'app/components/settings/Module';
@@ -291,20 +292,21 @@ class Settings extends React.PureComponent<null, State> {
     );
 
     const isAllValid = !warnings || Object.keys(warnings).length === 0;
+    const web = isWeb();
 
     return (
       <div className="studio-container settings-studio">
         <div className="settings-gradient-overlay" />
         <div className="form general">
           <General
-            isWeb={window.FLUX.version === 'web'}
+            isWeb={web}
             supportedLangs={supported_langs}
             notificationOptions={notificationOptions}
             changeActiveLang={this.changeActiveLang}
             updateConfigChange={this.updateConfigChange}
           />
           <Update
-            isWeb={window.FLUX.version === 'web'}
+            isWeb={web}
             updateNotificationOptions={updateNotificationOptions}
             updateConfigChange={this.updateConfigChange}
           />
@@ -315,7 +317,7 @@ class Settings extends React.PureComponent<null, State> {
             updateConfigChange={this.updateConfigChange}
           />
           <AutoSave
-            isWeb={window.FLUX.version === 'web'}
+            isWeb={web}
             autoSaveOptions={autoSaveOptions}
             editingAutosaveConfig={editingAutosaveConfig}
             warnings={warnings}

--- a/src/web/app/svgedit/interaction/mouseInteractions.ts
+++ b/src/web/app/svgedit/interaction/mouseInteractions.ts
@@ -1,29 +1,30 @@
 /* eslint-disable no-case-declarations */
+import BeamboxPreference from 'app/actions/beambox/beambox-preference';
+import clipboard from 'app/svgedit/operations/clipboard';
 import constant from 'app/actions/beambox/constant';
 import createNewText from 'app/svgedit/text/createNewText';
 import eventEmitterFactory from 'helpers/eventEmitterFactory';
-import PreviewModeController from 'app/actions/beambox/preview-mode-controller';
-import presprayArea from 'app/actions/canvas/prespray-area';
 import history from 'app/svgedit/history/history';
-import selector from 'app/svgedit/selector';
-import * as LayerHelper from 'helpers/layer/layer-helper';
-import BeamboxPreference from 'app/actions/beambox/beambox-preference';
+import ISVGCanvas from 'interfaces/ISVGCanvas';
+import isWeb from 'helpers/is-web';
 import LayerPanelController from 'app/views/beambox/Right-Panels/contexts/LayerPanelController';
 import ObjectPanelController from 'app/views/beambox/Right-Panels/contexts/ObjectPanelController';
-import TopBarController from 'app/views/beambox/TopBar/contexts/TopBarController';
-import * as TutorialController from 'app/views/tutorials/tutorialController';
-import TutorialConstants from 'app/constants/tutorial-constants';
-import clipboard from 'app/svgedit/operations/clipboard';
-import TopBarHintsController from 'app/views/beambox/TopBar/contexts/TopBarHintsController';
-import touchEvents from 'app/svgedit/touchEvents';
-import textEdit from 'app/svgedit/text/textedit';
+import PreviewModeController from 'app/actions/beambox/preview-mode-controller';
+import presprayArea from 'app/actions/canvas/prespray-area';
+import rotaryAxis from 'app/actions/canvas/rotary-axis';
 import SymbolMaker from 'helpers/symbol-maker';
+import selector from 'app/svgedit/selector';
+import TopBarController from 'app/views/beambox/TopBar/contexts/TopBarController';
+import TopBarHintsController from 'app/views/beambox/TopBar/contexts/TopBarHintsController';
+import TutorialConstants from 'app/constants/tutorial-constants';
+import textEdit from 'app/svgedit/text/textedit';
+import touchEvents from 'app/svgedit/touchEvents';
 import updateElementColor from 'helpers/color/updateElementColor';
-import ISVGCanvas from 'interfaces/ISVGCanvas';
+import workareaManager from 'app/svgedit/workarea';
+import * as LayerHelper from 'helpers/layer/layer-helper';
+import * as TutorialController from 'app/views/tutorials/tutorialController';
 import { getSVGAsync } from 'helpers/svg-editor-helper';
 import { MouseButtons } from 'app/constants/mouse-constants';
-import rotaryAxis from 'app/actions/canvas/rotary-axis';
-import workareaManager from 'app/svgedit/workarea';
 
 let svgEditor;
 let svgCanvas: ISVGCanvas;
@@ -1296,7 +1297,7 @@ const mouseUp = async (evt: MouseEvent, blocked = false) => {
           if (selected.tagName === 'text') {
             const curText = textEdit.getCurText();
             curText.font_size = selected.getAttribute('font-size');
-            if (window.os === 'MacOS' && window.FLUX.version !== 'web') {
+            if (window.os === 'MacOS' && !isWeb()) {
               curText.font_family = selected.getAttribute('data-font-family');
             } else {
               curText.font_family = selected.getAttribute('font-family');
@@ -1858,7 +1859,7 @@ const registerEvents = () => {
   svgCanvas.getContainer().addEventListener('mouseenter', mouseEnter);
   svgCanvas.getContainer().addEventListener('dblclick', dblClick);
 
-  if (window.FLUX.version === 'web') {
+  if (isWeb()) {
     const onWindowScroll = (e) => {
       if (e.ctrlKey) e.preventDefault();
     };

--- a/src/web/app/views/beambox/NetworkTestingPanel.tsx
+++ b/src/web/app/views/beambox/NetworkTestingPanel.tsx
@@ -8,6 +8,7 @@ import AlertConstants from 'app/constants/alert-constants';
 import browser from 'implementations/browser';
 import Discover from 'helpers/api/discover';
 import i18n from 'helpers/i18n';
+import isWeb from 'helpers/is-web';
 import network from 'implementations/network';
 import os from 'implementations/os';
 import Progress from 'app/actions/progress-caller';
@@ -196,7 +197,7 @@ class NetworkTestingPanel extends React.Component<Props> {
 
   renderLocalIP(): JSX.Element {
     const { localIps } = this;
-    if (!localIps.length && window.FLUX.version === 'web') return null;
+    if (!localIps.length && isWeb()) return null;
     return <Form.Item label={LANG.local_ip}>{localIps.join(', ')}</Form.Item>;
   }
 

--- a/src/web/app/views/beambox/SvgNestButtons.tsx
+++ b/src/web/app/views/beambox/SvgNestButtons.tsx
@@ -8,6 +8,7 @@ import Alert from 'app/actions/alert-caller';
 import getClipperLib from 'helpers/clipper/getClipperLib';
 import history from 'app/svgedit/history/history';
 import i18n from 'helpers/i18n';
+import isWeb from 'helpers/is-web';
 import Modal from 'app/widgets/Modal';
 import requirejsHelper from 'helpers/requirejs-helper';
 import workareaManager from 'app/svgedit/workarea';
@@ -15,12 +16,15 @@ import { getSVGAsync } from 'helpers/svg-editor-helper';
 
 let svgCanvas;
 let svgedit;
-getSVGAsync((globalSVG) => { svgCanvas = globalSVG.Canvas; svgedit = globalSVG.Edit; });
+getSVGAsync((globalSVG) => {
+  svgCanvas = globalSVG.Canvas;
+  svgedit = globalSVG.Edit;
+});
 
 const LANG = i18n.lang.beambox.tool_panels;
 
 async function setUpSvgNest() {
-  if (window.FLUX.version === 'web') {
+  if (isWeb()) {
     await requirejsHelper('js/lib/svg-nest/svgnest');
     await requirejsHelper('js/lib/svg-nest/util/geometryutil');
     await requirejsHelper('js/lib/svg-nest/util/parallel');
@@ -63,7 +67,12 @@ class SvgNestButtons extends React.Component<Props, State> {
       containerPoints = ClipperLib.dPathtoPointPathsAndScale(containerDpath, rotation, 1);
     } else {
       const { width: w, height: h } = workareaManager;
-      containerPoints = [{ x: 0, y: 0 }, { x: w, y: 0 }, { x: w, y: h }, { x: 0, y: h }];
+      containerPoints = [
+        { x: 0, y: 0 },
+        { x: w, y: 0 },
+        { x: w, y: h },
+        { x: 0, y: h },
+      ];
     }
 
     const elemPoints = [];
@@ -214,7 +223,10 @@ class SvgNestButtons extends React.Component<Props, State> {
         for (let i = 0; i < layerNumber; i += 1) {
           const name = drawing.getLayerName(i);
           const layer = drawing.getLayerByName(name);
-          if (layer.getAttribute('display') === 'none' || layer.getAttribute('data-lock') === 'true') {
+          if (
+            layer.getAttribute('display') === 'none' ||
+            layer.getAttribute('data-lock') === 'true'
+          ) {
             continue;
           }
           const { childNodes } = layer;
@@ -262,7 +274,7 @@ class SvgNestButtons extends React.Component<Props, State> {
     const { isWorking } = this.state;
     // eslint-disable-next-line no-underscore-dangle
     const endText = LANG._nest.end;
-    const className = classNames('svg-nest-buttons', { win: window.FLUX.version !== 'web' && window.os === 'Windows' });
+    const className = classNames('svg-nest-buttons', { win: !isWeb() && window.os === 'Windows' });
     if (isWorking) {
       return (
         <Modal className={{ 'no-background': true }}>

--- a/src/web/app/widgets/ColorPickerMobile.tsx
+++ b/src/web/app/widgets/ColorPickerMobile.tsx
@@ -4,6 +4,7 @@ import { Color } from 'antd/es/color-picker';
 import { ColorPicker, Button, Input, Popover } from 'antd';
 
 import ColorBlock from 'app/components/beambox/right-panel/ColorBlock';
+import isWeb from 'helpers/is-web';
 import useI18n from 'helpers/useI18n';
 
 import styles from './ColorPicker.module.scss';
@@ -18,7 +19,7 @@ interface Props {
 const getDisplayValue = (c: string) =>
   !c || c === 'none' ? '00000000' : c.replace('#', '').toUpperCase();
 const isHex = (c: string) => c && c.match(/^[A-Fa-f0-9]{6}$/);
-const isWhiteTopBar = window.os !== 'MacOS' && window.FLUX.version !== 'web';
+const isWhiteTopBar = window.os !== 'MacOS' && !isWeb();
 
 const ColorPickerMobile = ({ color, onChange, open, onClose }: Props): JSX.Element => {
   const lang = useI18n().alert;

--- a/src/web/helpers/InsecureWebsocket.ts
+++ b/src/web/helpers/InsecureWebsocket.ts
@@ -1,5 +1,6 @@
 import alertCaller from 'app/actions/alert-caller';
 import alertConstants from 'app/constants/alert-constants';
+import browser from 'implementations/browser';
 import i18n from 'helpers/i18n';
 import isWeb from 'helpers/is-web';
 import switchProtocol from 'helpers/switch-protocol';
@@ -29,9 +30,9 @@ let chromeExtensionAlertPopped = false;
 export const checkFluxTunnel = (): boolean => {
   window.dispatchEvent(new CustomEvent('CheckFluxTunnel'));
   if (!fluxTunnelLoaded && isWeb()) {
-    const browser = getBrowser();
+    const browserName = getBrowser();
     const isHttps = window.location.protocol === 'https:';
-    if (browser !== 'Chrome' && isHttps) {
+    if (browserName !== 'Chrome' && isHttps) {
       switchProtocol('http:');
       return false;
     }
@@ -44,7 +45,7 @@ export const checkFluxTunnel = (): boolean => {
         message: i18n.lang.insecure_websocket.extension_not_deteced_description,
         buttonType: alertConstants.CONFIRM_CANCEL,
         onConfirm: () => {
-          console.log('TODO: Open Chrome extension page');
+          browser.open('https://chromewebstore.google.com/detail/beam-studio-connect/kopngdknlbamdmehbclgbkcekligncla');
         },
         onCancel: () => switchProtocol('http:'),
       });

--- a/src/web/helpers/InsecureWebsocket.ts
+++ b/src/web/helpers/InsecureWebsocket.ts
@@ -11,7 +11,9 @@ let fluxTunnelLoaded = false;
 window.addEventListener('FluxTunnelLoaded', () => {
   fluxTunnelLoaded = true;
   if (isWeb() && window.location.protocol === 'http:') {
+    alertCaller.popById('insecure_websocket');
     alertCaller.popUp({
+      id: 'insecure_websocket',
       caption: i18n.lang.insecure_websocket.extension_detected,
       message: i18n.lang.insecure_websocket.extension_detected_description,
       buttonType: alertConstants.CONFIRM_CANCEL,
@@ -35,7 +37,9 @@ export const checkFluxTunnel = (): boolean => {
     }
     failedCount += 1;
     if (failedCount > 30 && isHttps && !chromeExtensionAlertPopped) {
+      alertCaller.popById('insecure_websocket');
       alertCaller.popUp({
+        id: 'insecure_websocket',
         caption: i18n.lang.insecure_websocket.extension_not_deteced,
         message: i18n.lang.insecure_websocket.extension_not_deteced_description,
         buttonType: alertConstants.CONFIRM_CANCEL,

--- a/src/web/helpers/InsecureWebsocket.ts
+++ b/src/web/helpers/InsecureWebsocket.ts
@@ -1,0 +1,104 @@
+const wrappedSockets = {};
+
+let fluxTunnelLoaded = false;
+window.addEventListener('FluxTunnelLoaded', () => {
+  fluxTunnelLoaded = true;
+});
+window.dispatchEvent(new CustomEvent('CheckFluxTunnel'));
+
+export const checkFluxTunnel = (): boolean => {
+  window.dispatchEvent(new CustomEvent('CheckFluxTunnel'));
+  return fluxTunnelLoaded;
+};
+
+class InsecureWebsocket {
+  id: string;
+
+  url: string;
+
+  protocol: string;
+
+  onopen: () => void;
+
+  onerror: () => void;
+
+  onmessage: (message: string) => void;
+
+  onclose: (data: { code?: number; reason: string; }) => void;
+
+  readyState = 0;
+
+  constructor(url: string, protocol?: string) {
+    const id = Math.random().toString(36).substring(2, 15);
+    this.id = id;
+    wrappedSockets[id] = this;
+    this.url = url;
+    this.protocol = protocol;
+    this.onopen = () => {
+      console.log('WebSocket connection established (default message)', id);
+    };
+    this.onerror = () => {};
+    this.onmessage = () => {};
+    this.onclose = () => {};
+    if (!checkFluxTunnel()) {
+      console.warn('FluxTunnel is not loaded');
+      setTimeout(() => {
+        this.onerror();
+        this.onclose({ reason: 'FluxTunnel is not loaded' });
+      }, 100);
+    } else {
+      console.log('Creating websocket in insecure websocket', id, 'url:', url, protocol);
+      const event = new CustomEvent('CreateWebsocket', { detail: { id, url, protocol } });
+      window.dispatchEvent(event);
+    }
+  }
+
+  send(message: unknown): void {
+    const event = new CustomEvent('SendMessage', { detail: { id: this.id, message } });
+    window.dispatchEvent(event);
+  }
+
+  close(): void {
+    this.readyState = 2;
+    const event = new CustomEvent('CloseWebsocket', { detail: { id: this.id } });
+    window.dispatchEvent(event);
+  }
+}
+
+window.addEventListener('InsecureWebsocket', (e: any) => {
+  const { detail } = e;
+  const { id, type, message } = detail;
+  if (!wrappedSockets[id]) {
+    // console.warn('InsecureWebsocket Unknown websocket id', id);
+    return;
+  }
+  switch (type) {
+    case 'WEBSOCKET_CREATED':
+      break;
+    case 'WEBSOCKET_OPENED':
+      wrappedSockets[id].readyState = 1;
+      wrappedSockets[id].onopen();
+      break;
+    case 'WEBSOCKET_MESSAGE':
+      wrappedSockets[id].onmessage({ data: message });
+      break;
+    case 'WEBSOCKET_CLOSED':
+      wrappedSockets[id].readyState = 3;
+      wrappedSockets[id].onclose();
+      break;
+    case 'WEBSOCKET_ERROR':
+      wrappedSockets[id].onerror(message);
+      break;
+    default:
+      console.warn('InsecureWebsocket Unknown event type', type);
+      break;
+  }
+});
+
+window.onbeforeunload = () => {
+  Object.keys(wrappedSockets).forEach((id) => {
+    wrappedSockets[id]?.close();
+  });
+};
+
+export default InsecureWebsocket;

--- a/src/web/helpers/absolute-position-helper.ts
+++ b/src/web/helpers/absolute-position-helper.ts
@@ -1,6 +1,7 @@
 import beamboxPreference from 'app/actions/beambox/beambox-preference';
 import Constant from 'app/actions/beambox/constant';
 import isDev from 'helpers/is-dev';
+import isWeb from 'helpers/is-web';
 import { modelsWithModules } from 'app/constants/layer-module/layer-modules';
 
 export enum TopRef {
@@ -17,7 +18,7 @@ export enum RightRef {
   PATH_PREVIEW_BTN = 3,
 }
 
-const isMacOrWeb = window.os === 'MacOS' || window.FLUX.version === 'web';
+const isMacOrWeb = window.os === 'MacOS' || isWeb();
 
 export const calculateTop = (top: number, ref: TopRef = TopRef.WINDOW): number => {
   switch (ref) {

--- a/src/web/helpers/api/discover.ts
+++ b/src/web/helpers/api/discover.ts
@@ -82,15 +82,15 @@ const onMessage = (device) => {
 };
 const poke = (targetIP: string) => {
   if (!targetIP) return;
-  ws.send(JSON.stringify({ cmd: 'poke', ipaddr: targetIP }));
+  ws?.send(JSON.stringify({ cmd: 'poke', ipaddr: targetIP }));
 };
 const pokeTcp = (targetIP: string) => {
   if (!targetIP) return;
-  ws.send(JSON.stringify({ cmd: 'poketcp', ipaddr: targetIP }));
+  ws?.send(JSON.stringify({ cmd: 'poketcp', ipaddr: targetIP }));
 };
 const testTcp = (targetIP: string) => {
   if (!targetIP) return;
-  ws.send(JSON.stringify({ cmd: 'testtcp', ipaddr: targetIP }));
+  ws?.send(JSON.stringify({ cmd: 'testtcp', ipaddr: targetIP }));
 };
 
 const pokeIPAddr = storage.get('poke-ip-addr');
@@ -198,6 +198,6 @@ const initSmartUpnp = async () => {
 };
 initSmartUpnp();
 
-export const checkConnection = (): boolean => ws.currentState === ws.readyState.OPEN;
+export const checkConnection = (): boolean => ws?.currentState === ws?.readyState.OPEN;
 
 export default Discover;

--- a/src/web/helpers/auto-save-helper.ts
+++ b/src/web/helpers/auto-save-helper.ts
@@ -1,5 +1,6 @@
 /* eslint-disable no-console */
 import fs from 'implementations/fileSystem';
+import isWeb from 'helpers/is-web';
 import storage from 'implementations/storage';
 import { generateBeamBuffer } from 'helpers/file-export-helper';
 import { IConfig } from 'interfaces/IAutosave';
@@ -101,7 +102,7 @@ const stopAutoSave = (): void => {
 };
 
 const toggleAutoSave = (start = false): void => {
-  if (window.FLUX.version === 'web') return;
+  if (isWeb()) return;
   if (start) {
     const config = getConfig();
     const { enabled } = config;

--- a/src/web/helpers/browser.spec.ts
+++ b/src/web/helpers/browser.spec.ts
@@ -1,0 +1,31 @@
+let userAgentGetter: jest.SpyInstance;
+describe('test getBrowser', () => {
+  beforeEach(() => {
+    userAgentGetter = jest.spyOn(window.navigator, 'userAgent', 'get');
+    jest.resetModules();
+  });
+
+  test('test Chrome', async () => {
+    const { getBrowser } = await import('./browser');
+    userAgentGetter.mockReturnValue(
+      'Mozilla/5.0 AppleWebKit/537.36 (KHTML, like Gecko) Chrome/123.0.0.0 Safari/537.36'
+    );
+    expect(getBrowser()).toBe('Chrome');
+  });
+
+  test('test Edge', async () => {
+    const { getBrowser } = await import('./browser');
+    userAgentGetter.mockReturnValue(
+      'Mozilla/5.0 Chrome/123.0.0.0 Safari/537.36 Edg/123.0.0.0'
+    );
+    expect(getBrowser()).toBe('Edge');
+  });
+
+  test('test Firefox', async () => {
+    const { getBrowser } = await import('./browser');
+    userAgentGetter.mockReturnValue(
+      'Firefox'
+    );
+    expect(getBrowser()).toBe('Firefox');
+  });
+});

--- a/src/web/helpers/browser.ts
+++ b/src/web/helpers/browser.ts
@@ -1,0 +1,39 @@
+let cache: 'Chrome' | 'Edge' | 'Firefox' | 'Safari' | 'IE' | 'Unknown' | null = null;
+
+export const getBrowser = (): 'Chrome' | 'Edge' | 'Firefox' | 'Safari' | 'IE' | 'Unknown' => {
+  if (cache) {
+    return cache;
+  }
+  const { userAgent } = navigator;
+  // Detect Chrome
+  if (/Chrome/.test(userAgent) && !/Chromium/.test(userAgent) && !/Edg/.test(userAgent)) {
+    cache = 'Chrome';
+    return 'Chrome';
+  }
+  // Detect Chromium-based Edge
+  if (/Edg/.test(userAgent)) {
+    cache = 'Edge';
+    return 'Edge';
+  }
+  // Detect Firefox
+  if (/Firefox/.test(userAgent)) {
+    cache = 'Firefox';
+    return 'Firefox';
+  }
+  // Detect Safari
+  if (/Safari/.test(userAgent)) {
+    cache = 'Safari';
+    return 'Safari';
+  }
+  // Detect Internet Explorer
+  if (/Trident/.test(userAgent)) {
+    cache = 'IE';
+    return 'IE';
+  }
+  cache = 'Unknown';
+  return 'Unknown';
+};
+
+export default {
+  getBrowser,
+};

--- a/src/web/helpers/check-software.ts
+++ b/src/web/helpers/check-software.ts
@@ -1,6 +1,7 @@
 import alertCaller from 'app/actions/alert-caller';
 import alertConstants from 'app/constants/alert-constants';
 import i18n from 'helpers/i18n';
+import isWeb from 'helpers/is-web';
 import { IDeviceInfo } from 'interfaces/IDevice';
 import { modelsWithModules } from 'app/constants/layer-module/layer-modules';
 import { sprintf } from 'sprintf-js';
@@ -10,7 +11,7 @@ import versionCompare from './version-compare';
 export default function checkSoftwareForAdor(device: IDeviceInfo, show_alert = true): boolean {
   const { version } = window.FLUX;
   const { model } = device;
-  if (version !== 'web' && versionCompare(version, '2.2') && modelsWithModules.has(model)) {
+  if (!isWeb() && versionCompare(version, '2.2') && modelsWithModules.has(model)) {
     if (show_alert) {
       alertCaller.popUp({
         message: sprintf(i18n.lang.update.software.update_for_ador, version),

--- a/src/web/helpers/file-export-helper.ts
+++ b/src/web/helpers/file-export-helper.ts
@@ -8,6 +8,7 @@ import dialog from 'implementations/dialog';
 import dialogCaller from 'app/actions/dialog-caller';
 import fs from 'implementations/fileSystem';
 import i18n from 'helpers/i18n';
+import isWeb from 'helpers/is-web';
 import Progress from 'app/actions/progress-caller';
 import SymbolMaker from 'helpers/symbol-maker';
 import svgStringToCanvas from 'helpers/image/svgStringToCanvas';
@@ -210,7 +211,7 @@ const saveAsFile = async (): Promise<boolean> => {
     svgCanvas.setHasUnsavedChange(false, false);
     return true;
   }
-  if (window.FLUX.version === 'web') {
+  if (isWeb()) {
     svgCanvas.setHasUnsavedChange(false, false);
     return true;
   }

--- a/src/web/helpers/fonts/fontHelper.ts
+++ b/src/web/helpers/fonts/fontHelper.ts
@@ -2,6 +2,7 @@ import eventEmitterFactory from 'helpers/eventEmitterFactory';
 import getUtilWS from 'helpers/api/utils-ws';
 import i18n from 'helpers/i18n';
 import isFluxPlusActive from 'helpers/is-flux-plus-active';
+import isWeb from 'helpers/is-web';
 import localFontHelper from 'implementations/localFontHelper';
 import progressCaller from 'app/actions/progress-caller';
 import { FontDescriptor, FontDescriptorKeys, FontHelper, WebFont } from 'interfaces/IFont';
@@ -123,7 +124,7 @@ export default {
     return localFontHelper.getFontName(font) || font.family;
   },
   async getWebFontAndUpload(postscriptName: string) {
-    if (window.FLUX.version !== 'web') return true;
+    if (!isWeb()) return true;
     const utilWS = getUtilWS();
     const font = availableFonts.find((f) => f.postscriptName === postscriptName) as WebFont;
     const fileName = font?.fileName || `${postscriptName}.ttf`;
@@ -215,7 +216,7 @@ export default {
   applyMonotypeStyle: monotypeFonts.applyStyle,
   getMonotypeUrl: monotypeFonts.getUrlWithToken,
   usePostscriptAsFamily: (font?: FontDescriptor | string) => {
-    if (window.os !== 'MacOS' || window.FLUX.version === 'web' || !font) return false;
+    if (window.os !== 'MacOS' || isWeb() || !font) return false;
     const currentFont =
       typeof font === 'string' ? availableFonts?.find((f) => f.postscriptName === font) : font;
     if (currentFont) return 'path' in currentFont;

--- a/src/web/helpers/fonts/webFonts.ts
+++ b/src/web/helpers/fonts/webFonts.ts
@@ -1,3 +1,4 @@
+import isWeb from 'helpers/is-web';
 import { WebFont } from 'interfaces/IFont';
 
 const fonts: WebFont[] = [
@@ -1625,7 +1626,7 @@ const getAvailableFonts = (lang?: string): WebFont[] => {
       if (!font.supportLangs) return true;
       return font.supportLangs.includes(lang);
     });
-  if (window.FLUX.version !== 'web')
+  if (!isWeb())
     availableFonts = availableFonts.filter((font) => !font.fontkitError);
   return availableFonts;
 };

--- a/src/web/helpers/rating-helper.ts
+++ b/src/web/helpers/rating-helper.ts
@@ -1,6 +1,7 @@
 /* eslint-disable no-console */
 /* eslint-disable @typescript-eslint/dot-notation */
 import Dialog from 'app/actions/dialog-caller';
+import isWeb from 'helpers/is-web';
 import storage from 'implementations/storage';
 import { getInfo, submitRating } from 'helpers/api/flux-id';
 
@@ -69,7 +70,7 @@ const setDefaultRatingRecord = (): void => {
 };
 
 const init = (): void => {
-  if (window.FLUX.version === 'web') return;
+  if (isWeb()) return;
   if (!storage.isExisting('rating-record')) {
     setDefaultRatingRecord();
   } else {

--- a/src/web/helpers/switch-protocol.spec.ts
+++ b/src/web/helpers/switch-protocol.spec.ts
@@ -1,0 +1,38 @@
+import switchProtocol from './switch-protocol';
+
+jest.mock('./is-web', () => () => true);
+
+describe('test switchProtocol', () => {
+  beforeEach(() => {
+    Object.defineProperty(window, 'location', {
+      value: {
+        href: 'http://localhost:3000/',
+      },
+      writable: true,
+    });
+  });
+
+  test('test switch to https', () => {
+    window.location.href = 'http://localhost:3000/';
+    switchProtocol();
+    expect(window.location.href).toBe('https://localhost:3000/');
+  });
+
+  test('test switch to http', () => {
+    window.location.href = 'http://localhost:3000/';
+    switchProtocol('http:');
+    expect(window.location.href).toBe('http://localhost:3000/');
+  });
+
+  test('test switch to https when current is https', () => {
+    window.location.href = 'https://localhost:3000/';
+    switchProtocol();
+    expect(window.location.href).toBe('http://localhost:3000/');
+  });
+
+  test('test switch to http when current is https', () => {
+    window.location.href = 'https://localhost:3000/';
+    switchProtocol('https:');
+    expect(window.location.href).toBe('https://localhost:3000/');
+  });
+});

--- a/src/web/helpers/switch-protocol.ts
+++ b/src/web/helpers/switch-protocol.ts
@@ -1,0 +1,11 @@
+import isWeb from './is-web';
+
+const switchProtocol = (protocol?: string): void => {
+  if (!isWeb()) return;
+  const urlObj = new URL(window.location.href);
+  if (protocol === urlObj.protocol) return;
+  urlObj.protocol = protocol ?? (urlObj.protocol === 'http:' ? 'https:' : 'http:');
+  window.location.href = urlObj.href;
+};
+
+export default switchProtocol;

--- a/src/web/helpers/symbol-maker.ts
+++ b/src/web/helpers/symbol-maker.ts
@@ -7,6 +7,7 @@
 import communicator from 'implementations/communicator';
 import history from 'app/svgedit/history/history';
 import ImageSymbolWorker from 'helpers/symbol-helper/image-symbol.worker';
+import isWeb from 'helpers/is-web';
 import Progress from 'app/actions/progress-caller';
 import updateElementColor from 'helpers/color/updateElementColor';
 import workareaManager from 'app/svgedit/workarea';
@@ -476,7 +477,7 @@ const makeImageSymbol = async (
       strokeWidth,
       fullColor,
     };
-    const imageUrl = window.FLUX.version === 'web' ? await svgToImgUrl(param) : await svgToImgUrlByShadowWindow(param);
+    const imageUrl = isWeb() ? await svgToImgUrl(param) : await svgToImgUrlByShadowWindow(param);
     URL.revokeObjectURL(svgUrl);
     if (!imageSymbol) {
       const image = svgdoc.createElementNS(NS.SVG, 'image');

--- a/src/web/helpers/web-need-connection-helper.ts
+++ b/src/web/helpers/web-need-connection-helper.ts
@@ -2,12 +2,13 @@ import alertCaller from 'app/actions/alert-caller';
 import alertConstants from 'app/constants/alert-constants';
 import fileExportHelper from 'helpers/file-export-helper';
 import i18n from 'helpers/i18n';
+import isWeb from 'helpers/is-web';
 import ObjectPanelController from 'app/views/beambox/Right-Panels/contexts/ObjectPanelController';
 
 import { checkConnection } from 'helpers/api/discover';
 
 const webNeedConnectionWrapper = <T>(callback: () => T | Promise<T>): T | Promise<T> => {
-  if (window.FLUX.version === 'web' && !checkConnection()) {
+  if (isWeb() && !checkConnection()) {
     alertCaller.popUp({
       caption: i18n.lang.alert.oops,
       message: i18n.lang.device_selection.no_device_web,

--- a/src/web/helpers/websocket.ts
+++ b/src/web/helpers/websocket.ts
@@ -120,7 +120,6 @@ export default function (options) {
       handleCreateWebSocketFailed();
       return null;
     }
-    // TODO: determine when to use InsecureWebsocket
     const WebSocketClass =
       isWeb() && window.location.protocol === 'https:' && checkFluxTunnel()
         ? InsecureWebsocket

--- a/src/web/interfaces/ILang.d.ts
+++ b/src/web/interfaces/ILang.d.ts
@@ -1764,4 +1764,10 @@ export interface ILang {
     download_success: string;
     upload_success: string;
   };
+  insecure_websocket: {
+    extension_detected: string;
+    extension_detected_description: string;
+    extension_not_deteced: string;
+    extension_not_deteced_description: string;
+  };
 }


### PR DESCRIPTION
Add `isWeb` helper to unify web version detection.
Add [insecure websocket class](https://github.com/flux3dp/beam-studio-core/blob/41da1018a74367d070539ba95e496f8652249ee5/src/web/helpers/InsecureWebsocket.ts) for google chrome extension in the future.
When is in http and detect chrome extension: ask if the user want to change to https
When in https and browser is not chrome: redirect to http
When in https and browser is chrome and unable to detect chrome extension: ask the users if they want to install the extension