### PR TITLE
perf: material test generator preview slow

### DIFF
--- a/src/web/app/components/dialogs/MaterialTestGeneratorPanel/TableSettingForm.tsx
+++ b/src/web/app/components/dialogs/MaterialTestGeneratorPanel/TableSettingForm.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
 import UnitInput from 'app/widgets/UnitInput';
 import useI18n from 'helpers/useI18n';
-import { Flex, Select } from 'antd';
+import { Flex } from 'antd';
+import Select from 'app/widgets/AntdSelect';
 import { Detail, tableParams, TableSetting } from './TableSetting';
 import styles from './Form.module.scss';
 
@@ -28,14 +29,10 @@ export default function TableSettingForm({
   } = useI18n();
   const lengthUnit = isInch ? 'in/s' : 'mm/s';
   const settingEntries = React.useMemo(
-    () =>
-      Object.entries(tableSetting).sort(([a], [b]) => b.localeCompare(a)) as Array<[Param, Detail]>,
+    () => Object.entries(tableSetting) as Array<[Param, Detail]>,
     [tableSetting]
   );
-  const options = React.useMemo(
-    () => settingEntries.map(([key]) => ({ value: key, label: tLaserPanel[key] })),
-    [settingEntries, tLaserPanel]
-  );
+  const options = tableParams.map((value) => ({ value, label: tLaserPanel[value] }));
 
   const handleSelectChange = (value: string, index: number) => {
     const currentKey = settingEntries.find(([, { selected }]) => selected === index)?.[0];
@@ -78,7 +75,7 @@ export default function TableSettingForm({
         <Select
           className={styles.input}
           options={options}
-          value={options.find(({ value }) => tableSetting[value].selected === index)?.value}
+          value={key}
           onChange={(value) => handleSelectChange(value, index)}
         />
         {['min', 'max'].map((prefix) => (

--- a/src/web/app/components/dialogs/MaterialTestGeneratorPanel/TextSettingForm.tsx
+++ b/src/web/app/components/dialogs/MaterialTestGeneratorPanel/TextSettingForm.tsx
@@ -2,7 +2,8 @@ import React from 'react';
 
 import UnitInput from 'app/widgets/UnitInput';
 import useI18n from 'helpers/useI18n';
-import { Flex, Select } from 'antd';
+import { Flex } from 'antd';
+import Select from 'app/widgets/AntdSelect';
 import presetHelper from 'helpers/presets/preset-helper';
 import useWorkarea from 'helpers/hooks/useWorkarea';
 import layerModuleHelper from 'helpers/layer-module/layer-module-helper';

--- a/src/web/app/components/dialogs/MaterialTestGeneratorPanel/index.tsx
+++ b/src/web/app/components/dialogs/MaterialTestGeneratorPanel/index.tsx
@@ -236,15 +236,14 @@ const MaterialTestGeneratorPanel = ({ onClose }: Props): JSX.Element => {
   const handlePreview = () => {
     const svgInfos = generateSvgInfo({ tableSetting, blockSetting });
 
-    undoManager.unApply(batchCmd.current);
+    batchCmd.current.unapply();
+    // to prevent layer id conflict
+    svgCanvas.identifyLayers();
 
     batchCmd.current = new history.BatchCommand('Material Test Generator');
 
     generateBlocks(svgInfos, blockSetting, batchCmd.current);
     generateText(svgInfos, blockSetting, batchCmd.current);
-
-    svgEditor.updateContextPanel();
-    LayerPanelController.updateLayerPanel();
   };
 
   const handleExport = () => {
@@ -252,11 +251,15 @@ const MaterialTestGeneratorPanel = ({ onClose }: Props): JSX.Element => {
 
     svgEditor.updateContextPanel();
     LayerPanelController.updateLayerPanel();
+
     onClose();
   };
 
   const handleCancel = () => {
-    undoManager.unApply(batchCmd.current);
+    batchCmd.current.unapply();
+    // to prevent layer id conflict
+    svgCanvas.identifyLayers();
+
     onClose();
   };
 

--- a/src/web/app/svgedit/history/history.ts
+++ b/src/web/app/svgedit/history/history.ts
@@ -62,7 +62,7 @@ export class BaseHistoryCommand implements ICommand {
     throw Error('unapply not implemented');
   };
 
-  unapply(handler: IHistoryHandler): void {
+  unapply(handler?: IHistoryHandler): void {
     handler?.handleHistoryEvent(HistoryEventTypes.BEFORE_UNAPPLY, this);
     this.onBefore?.();
     this.doUnapply(handler);

--- a/src/web/app/svgedit/history/undoManager.ts
+++ b/src/web/app/svgedit/history/undoManager.ts
@@ -71,10 +71,6 @@ export class UndoManager implements IUndoManager {
     return false;
   }
 
-  unApply(cmd: BaseHistoryCommand): void {
-    cmd.unapply(this.handler);
-  }
-
   redo(): boolean {
     if (this.undoStackPointer < this.undoStack.length && this.undoStack.length > 0) {
       const cmd = this.undoStack[this.undoStackPointer];

--- a/src/web/interfaces/ISVGCanvas.d.ts
+++ b/src/web/interfaces/ISVGCanvas.d.ts
@@ -182,4 +182,5 @@ export default interface ISVGCanvas {
   uniquifyElems: (elem: SVGElement) => void;
   groupSvgElem: (elem: SVGElement) => void;
   convertGradients: (elem: Element) => void;
+  identifyLayers: () => void;
 }


### PR DESCRIPTION
## Overview

1. [perf(dialogs): only trigger update-layer-panel when on-export](https://github.com/flux3dp/beam-studio-core/commit/aa820f60ebce4efaf06e4d6f1245be824fcb41d1)
2. [feat(svgedit-history): remove un-apply method from undo-manager](https://github.com/flux3dp/beam-studio-core/commit/8788938614025a835ae4c362be46d0910607b4bb)
3. [feat: add identify-layers to svgcanvas interface](https://github.com/flux3dp/beam-studio-core/commit/3d2d4b4c677d62cbf295f79101e7438b3d08c554)
4. [feat: make base-history-command can trigger unapply even if no handler](https://github.com/flux3dp/beam-studio-core/commit/5c84dc4219d1420b14432a56e6e7f6397b5eb2d0)