### PR TITLE
fix: promark hint i18n

### DIFF
--- a/src/web/app/lang/zh-cn.ts
+++ b/src/web/app/lang/zh-cn.ts
@@ -395,7 +395,7 @@ const lang: ILang = {
       finish_setting: '开始创作',
       check_swiftray_connection: '正在检查服务器连接',
       check_swiftray_connection_unreachable: '服务器无法访问',
-      promark_hint: '如果您多次无法通过USB连接，请参考<a target="_blank" href="https://support.flux3dp.com/hc/en-us/articles/11195313944975">帮助中心的文章</a>。',
+      promark_hint: '如果您持续遇到 USB 连线失败问题，请参考<a target="_blank" href="https://support.flux3dp.com/hc/en-us/articles/11195313944975">说明中心文章</a>。',
       alert: {
         swiftray_connection_error: '无法连接到服务器。请重新启动Beam Studio并重试。',
       },

--- a/src/web/app/lang/zh-tw.ts
+++ b/src/web/app/lang/zh-tw.ts
@@ -395,7 +395,7 @@ const lang: ILang = {
       finish_setting: '開始創作',
       check_swiftray_connection: '正在檢查伺服器連線',
       check_swiftray_connection_unreachable: '伺服器無法連線',
-      promark_hint: '如果您無法反覆透過USB連線，請參考<a target="_blank" href="https://support.flux3dp.com/hc/zh-tw/articles/11195313944975">說明中心文章</a>。',
+      promark_hint: '如果您持續遇到 USB 連線失敗問題，請參考<a target="_blank" href="https://support.flux3dp.com/hc/zh-tw/articles/11195313944975">說明中心文章</a>。',
       alert: {
         swiftray_connection_error: '無法連接到伺服器。請重新啟動Beam Studio並重試。',
       },


### PR DESCRIPTION
## Overview

1. [fix(lang): fix zh-tw zh-cn, promark_hint i18n](https://github.com/flux3dp/beam-studio-core/commit/1567daf1672fd1fa3fcb0842560d2145052b17e5)