### PR TITLE
fix(pages): add device-master select during promark test

### DIFF
--- a/src/web/app/pages/ConnectMachineIp/index.tsx
+++ b/src/web/app/pages/ConnectMachineIp/index.tsx
@@ -206,6 +206,10 @@ const ConnectMachineIp = (): JSX.Element => {
       return;
     }
 
+    // for correctly select promark device serial
+    const res = await deviceMaster.select(device);
+    console.log('🚀 ~ file: index.tsx:212 ~ handleStartTestForPromark ~ deviceMaster.select:', res);
+
     await testCamera(device);
   };
 


### PR DESCRIPTION
## Overview

1. [fix(pages): add device-master select during promark test](https://github.com/flux3dp/beam-studio-core/commit/cffd3e2e5159c1065a6082323744d3a3d981c891)
// keep this console.log for debug if the device selection is not succeed.