### PR TITLE
fix: preset no default

### DIFF
--- a/src/web/app/components/dialogs/PresetsManagementPanel/LaserInputs.spec.tsx
+++ b/src/web/app/components/dialogs/PresetsManagementPanel/LaserInputs.spec.tsx
@@ -67,9 +67,10 @@ describe('LaserInputs', () => {
     fireEvent.change(repeatInput, { target: { value: '50' } });
     expect(handleChange).toBeCalledTimes(3);
     expect(handleChange).toHaveBeenLastCalledWith('repeat', 50);
-    const zStepInput = getByTestId('zStep');
-    fireEvent.change(zStepInput, { target: { value: '50' } });
-    expect(handleChange).toBeCalledTimes(4);
-    expect(handleChange).toHaveBeenLastCalledWith('zStep', 50);
+    const focusStepInput = getByTestId('focusStep');
+    fireEvent.change(focusStepInput, { target: { value: '50' } });
+    // both focusStep and zStep should be updated
+    expect(handleChange).toBeCalledTimes(5);
+    expect(handleChange).toHaveBeenLastCalledWith('focusStep', 50);
   });
 });

--- a/src/web/app/components/dialogs/PresetsManagementPanel/LaserInputs.tsx
+++ b/src/web/app/components/dialogs/PresetsManagementPanel/LaserInputs.tsx
@@ -93,16 +93,24 @@ const LaserInputs = ({
         <div className={styles.field}>
           <div className={styles.label}>{tLaserPanel.z_step}</div>
           <UnitInput
-            data-testid="zStep"
+            data-testid="focusStep"
             className={styles.input}
-            disabled={preset.isDefault}
-            value={preset.zStep ?? baseConfig.zStep}
+            disabled={preset.isDefault || preset.repeat <= 1}
+            value={Math.max(preset.focusStep ?? baseConfig.focusStep, 0)}
             max={10}
             min={0}
             precision={isInch ? 2 : 1}
             addonAfter={lengthUnit}
             isInch={isInch}
-            onChange={(value) => handleChange('zStep', value)}
+            onChange={(value) => {
+              /**
+               * update both zStep and focusStep, to make the user experience consistent
+               * zStep is for beamo only
+               * focusStep is for the other models
+               */
+              handleChange('zStep', value);
+              handleChange('focusStep', value);
+            }}
           />
         </div>
       </div>

--- a/src/web/app/components/dialogs/PresetsManagementPanel/PresetsManagementPanel.spec.tsx
+++ b/src/web/app/components/dialogs/PresetsManagementPanel/PresetsManagementPanel.spec.tsx
@@ -60,8 +60,10 @@ jest.mock('app/actions/dialog-controller', () => ({
 }));
 
 const mockPostPresetChange = jest.fn();
+const mockGetDefaultConfig = jest.fn();
 jest.mock('helpers/layer/layer-config-helper', () => ({
   postPresetChange: (...args) => mockPostPresetChange(...args),
+  getDefaultConfig: () => mockGetDefaultConfig(),
 }));
 
 jest.mock('./Footer', () => ({ handleSave, handleReset, onClose }: any) => (

--- a/src/web/app/components/dialogs/PresetsManagementPanel/PresetsManagementPanel.tsx
+++ b/src/web/app/components/dialogs/PresetsManagementPanel/PresetsManagementPanel.tsx
@@ -18,7 +18,7 @@ import useI18n from 'helpers/useI18n';
 import useWorkarea from 'helpers/hooks/useWorkarea';
 import { addDialogComponent, isIdExist, popDialogById } from 'app/actions/dialog-controller';
 import { ConfigKey, ConfigKeyTypeMap, Preset } from 'interfaces/ILayerConfig';
-import { baseConfig, postPresetChange } from 'helpers/layer/layer-config-helper';
+import { baseConfig, getDefaultConfig, postPresetChange } from 'helpers/layer/layer-config-helper';
 import { getWorkarea } from 'app/constants/workarea-constants';
 import { promarkModels } from 'app/actions/beambox/constant';
 
@@ -221,12 +221,15 @@ const PresetsManagementPanel = ({ currentModule, initPreset, onClose }: Props): 
     });
     if (!name) return;
     if (editingPresets.find((p) => p.name === name || p.key === name)) {
-      alertCaller.popUpError({
-        message: tLaserPanel.existing_name,
-      });
+      alertCaller.popUpError({ message: tLaserPanel.existing_name });
       return;
     }
-    const newPreset: Preset = { name: name.trim(), isDefault: false, module: presetModule };
+    const newPreset: Preset = {
+      ...getDefaultConfig(),
+      name: name.trim(),
+      isDefault: false,
+      module: presetModule,
+    };
     if (presetModule === LayerModule.PRINTER) {
       newPreset.halftone = 1;
       newPreset.speed = baseConfig.printingSpeed;

--- a/src/web/app/components/dialogs/PresetsManagementPanel/PromarkInputs.tsx
+++ b/src/web/app/components/dialogs/PresetsManagementPanel/PromarkInputs.tsx
@@ -111,7 +111,7 @@ const PromarkInputs = ({
               <UnitInput
                 data-testid="focusStep"
                 className={styles.input}
-                disabled={preset.isDefault}
+                disabled={preset.isDefault || preset.repeat <= 1}
                 value={Math.max(preset.focusStep ?? defaultConfig.focusStep, 0)}
                 max={focusStepMax}
                 min={0}

--- a/src/web/app/components/dialogs/PresetsManagementPanel/__snapshots__/LaserInputs.spec.tsx.snap
+++ b/src/web/app/components/dialogs/PresetsManagementPanel/__snapshots__/LaserInputs.spec.tsx.snap
@@ -135,7 +135,7 @@ exports[`LaserInputs should render correctly 1`] = `
             1
           </p>
           <input
-            data-testid="zStep"
+            data-testid="focusStep"
             max="10"
             min="0"
             value="0"

--- a/src/web/app/components/dialogs/PresetsManagementPanel/__snapshots__/PromarkInputs.spec.tsx.snap
+++ b/src/web/app/components/dialogs/PresetsManagementPanel/__snapshots__/PromarkInputs.spec.tsx.snap
@@ -134,6 +134,7 @@ exports[`PromarkInputs should render correctly 1`] = `
           </p>
           <input
             data-testid="focusStep"
+            disabled=""
             max="10"
             min="0"
             value="1"

--- a/src/web/helpers/layer/layer-config-helper.ts
+++ b/src/web/helpers/layer/layer-config-helper.ts
@@ -76,6 +76,7 @@ export const baseConfig: Partial<ConfigKeyTypeMap> = {
   ink: BeamboxPreference.read('multipass-compensation') !== false ? 3 : 1,
   repeat: 1,
   height: -3,
+  // explicit for beamo model
   zStep: 0,
   diode: 0,
   configName: '',


### PR DESCRIPTION
## Overview

1. [fix(component): add default config to each new preset](https://github.com/flux3dp/beam-studio-core/commit/bca41de6bb300238f29a03cfe672becf8f423941) [[clickup]](https://app.clickup.com/t/86eqr16qe)
2. [fix(dialogs): update both z-step and focus-step on editing preset](https://github.com/flux3dp/beam-studio-core/commit/e11d332f13b195a2b5ee6a09f83cec1d16d57eef)