### PR TITLE
Fix UnitInput ref for antd 5.22

### DIFF
--- a/src/web/app/widgets/UnitInput.tsx
+++ b/src/web/app/widgets/UnitInput.tsx
@@ -39,7 +39,14 @@ const UnitInput = forwardRef<HTMLInputElement, Props>(
     const inputRef = useRef<HTMLInputElement>(null);
     const valueRef = useRef<number | undefined>(); // for onChange
 
-    useImperativeHandle(outerRef, () => inputRef.current, []);
+    useImperativeHandle(
+      outerRef,
+      () => {
+        const input = inputRef.current;
+        return input.parentNode?.querySelector('input') || input;
+      },
+      []
+    );
 
     const formatter = useCallback(
       (value: string | number) => {


### PR DESCRIPTION
Because antd ref was changed to `Proxy(HTMLInput)` so editing value is not available.
Use `parentNode?.querySelector` to get the real input