### PR TITLE
Fix web font ttc not found

### DIFF
--- a/src/web/app/actions/beambox/font-funcs.ts
+++ b/src/web/app/actions/beambox/font-funcs.ts
@@ -168,8 +168,8 @@ export const getFontObj = async (
       if ((font as FontDescriptor).path) {
         fontObj = localFontHelper.getLocalFont(font);
       } else {
+        const { fileName = `${postscriptName}.ttf`, collectionIdx = 0 } = font as WebFont;
         const protocol = isWeb() ? window.location.protocol : 'https:';
-        const fileName = (font as WebFont).fileName || `${postscriptName}.ttf`;
         let url = `${protocol}//beam-studio-web.s3.ap-northeast-1.amazonaws.com/fonts/${fileName}`;
         if ('hasLoaded' in font) {
           const monotypeUrl = await fontHelper.getMonotypeUrl(postscriptName);
@@ -181,6 +181,13 @@ export const getFontObj = async (
         try {
           // Font Collection
           fontObj = fontkit.create(buffer, font.postscriptName) as fontkit.Font;
+          if (!fontObj) {
+            const res = fontkit.create(buffer) as fontkit.FontCollection;
+            if (!res) {
+              throw new Error('Failed to create font collection');
+            }
+            fontObj = res.fonts[collectionIdx];
+          }
         } catch {
           // Single Font
           fontObj = fontkit.create(buffer) as fontkit.Font;

--- a/src/web/helpers/fonts/webFonts.ts
+++ b/src/web/helpers/fonts/webFonts.ts
@@ -708,6 +708,7 @@ const fonts: WebFont[] = [
     style: 'Regular',
     weight: 400,
     fileName: 'GenSenRounded-R.ttc',
+    collectionIdx: 1,
     supportLangs: ['zh-tw'],
   },
   {
@@ -727,6 +728,7 @@ const fonts: WebFont[] = [
     style: 'Regular',
     weight: 400,
     fileName: 'GenSenRounded-R.ttc',
+    collectionIdx: 0,
     supportLangs: ['ja'],
   },
   {
@@ -1626,8 +1628,7 @@ const getAvailableFonts = (lang?: string): WebFont[] => {
       if (!font.supportLangs) return true;
       return font.supportLangs.includes(lang);
     });
-  if (!isWeb())
-    availableFonts = availableFonts.filter((font) => !font.fontkitError);
+  if (!isWeb()) availableFonts = availableFonts.filter((font) => !font.fontkitError);
   return availableFonts;
 };
 


### PR DESCRIPTION
font kit failed to read name of some ttc fonts collections
add `collectionIdx` to webFonts, fall back to first font in ttc if not set
[slack](https://flux3dp.slack.com/archives/C2KV9ULLC/p1733901059899759)