### PR TITLE
fix(top-bar): disable path menu during selecting image, svg, dxf

### DIFF
--- a/src/web/app/actions/beambox/beambox-global-interaction.ts
+++ b/src/web/app/actions/beambox/beambox-global-interaction.ts
@@ -38,34 +38,38 @@ class BeamboxGlobalInteraction {
   }
 
   onObjectFocus(elems?) {
-    let selectedElements = elems || svgCanvas.getSelectedElems().filter((elem) => elem);
-    if (selectedElements.length === 0) {
+    let selectedElements = elems || svgCanvas.getSelectedElems().filter(Boolean);
+
+    if (!selectedElements.length) {
       return;
     }
+
+    const { tagName } = selectedElements[0];
+
     menu.enable(['DUPLICATE', 'DELETE', 'PATH']);
-    if (selectedElements[0].tagName === 'image') {
+
+    if (tagName === 'image') {
       menu.enable(['PHOTO_EDIT']);
-    } else if (selectedElements[0].tagName === 'use') {
+      menu.disable(['PATH']);
+    } else if (tagName === 'use') {
       menu.enable(['SVG_EDIT']);
-    } else if (selectedElements[0].tagName === 'path') {
+    } else if (tagName === 'path') {
       menu.enable(['DECOMPOSE_PATH']);
     }
+
     if (
       selectedElements.length > 0 &&
       selectedElements[0].getAttribute('data-tempgroup') === 'true'
     ) {
       selectedElements = Array.from(selectedElements[0].childNodes);
     }
-    if (
-      selectedElements?.length > 1 ||
-      (selectedElements?.length === 1 && selectedElements[0].tagName !== 'g')
-    ) {
+    if (selectedElements?.length > 1 || (selectedElements?.length === 1 && tagName !== 'g')) {
       menu.enable(['GROUP']);
     }
     if (
       selectedElements &&
       selectedElements.length === 1 &&
-      ['g', 'a', 'use'].includes(selectedElements[0].tagName) &&
+      ['g', 'a', 'use'].includes(tagName) &&
       !selectedElements[0].getAttribute('data-textpath-g') &&
       !selectedElements[0].getAttribute('data-pass-through')
     ) {
@@ -91,6 +95,6 @@ class BeamboxGlobalInteraction {
   }
 }
 
-const instance = new BeamboxGlobalInteraction();
+const beamboxGlobalInteraction = new BeamboxGlobalInteraction();
 
-export default instance;
+export default beamboxGlobalInteraction;

--- a/src/web/app/actions/beambox/beambox-global-interaction.ts
+++ b/src/web/app/actions/beambox/beambox-global-interaction.ts
@@ -44,7 +44,8 @@ class BeamboxGlobalInteraction {
       return;
     }
 
-    const { tagName } = selectedElements[0];
+    const firstElement = selectedElements[0];
+    const { tagName } = firstElement;
 
     menu.enable(['DUPLICATE', 'DELETE', 'PATH']);
 
@@ -53,25 +54,31 @@ class BeamboxGlobalInteraction {
       menu.disable(['PATH']);
     } else if (tagName === 'use') {
       menu.enable(['SVG_EDIT']);
+
+      if (
+        firstElement.getAttribute('data-svg') === 'true' ||
+        firstElement.getAttribute('data-dxf') === 'true'
+      ) {
+        menu.disable(['PATH']);
+      }
     } else if (tagName === 'path') {
       menu.enable(['DECOMPOSE_PATH']);
     }
 
-    if (
-      selectedElements.length > 0 &&
-      selectedElements[0].getAttribute('data-tempgroup') === 'true'
-    ) {
-      selectedElements = Array.from(selectedElements[0].childNodes);
+    if (selectedElements.length > 0 && firstElement.getAttribute('data-tempgroup') === 'true') {
+      selectedElements = Array.from(firstElement.childNodes);
     }
+
     if (selectedElements?.length > 1 || (selectedElements?.length === 1 && tagName !== 'g')) {
       menu.enable(['GROUP']);
     }
+
     if (
       selectedElements &&
       selectedElements.length === 1 &&
       ['g', 'a', 'use'].includes(tagName) &&
-      !selectedElements[0].getAttribute('data-textpath-g') &&
-      !selectedElements[0].getAttribute('data-pass-through')
+      !firstElement.getAttribute('data-textpath-g') &&
+      !firstElement.getAttribute('data-pass-through')
     ) {
       menu.enable(['UNGROUP']);
     }

--- a/src/web/app/components/beambox/top-bar/Menu.tsx
+++ b/src/web/app/components/beambox/top-bar/Menu.tsx
@@ -45,6 +45,7 @@ export default function Menu({ email }: Props): JSX.Element {
   const [decomposePathDisabled, setDecomposePathDisabled] = useState(true);
   const [groupDisabled, setGroupDisabled] = useState(true);
   const [ungroupDisabled, setUngroupDisabled] = useState(true);
+  const [pathDisabled, setPathDisabled] = useState(true);
   const [imageEditDisabled, setImageEditDisabled] = useState(true);
   const menuItemUpdater = {
     DUPLICATE: setDuplicateDisabled,
@@ -52,6 +53,7 @@ export default function Menu({ email }: Props): JSX.Element {
     DECOMPOSE_PATH: setDecomposePathDisabled,
     GROUP: setGroupDisabled,
     UNGROUP: setUngroupDisabled,
+    PATH: setPathDisabled,
     PHOTO_EDIT: setImageEditDisabled,
   };
   const isMobile = useIsMobile();
@@ -342,7 +344,7 @@ export default function Menu({ email }: Props): JSX.Element {
           {hotkey('ungroup')}
         </MenuItem>
         <MenuDivider />
-        <SubMenu label={menuCms.path}>
+        <SubMenu disabled={pathDisabled} label={menuCms.path}>
           <MenuItem onClick={() => callback('OFFSET')}>{menuCms.offset}</MenuItem>
           <MenuItem disabled={decomposePathDisabled} onClick={() => callback('DECOMPOSE_PATH')}>
             {menuCms.decompose_path}

--- a/src/web/app/svgedit/operations/import/importSvg.ts
+++ b/src/web/app/svgedit/operations/import/importSvg.ts
@@ -281,12 +281,11 @@ const importSvg = async (
 
   if (filteredNewElements.length === 0) {
     svgCanvas.clearSelection();
-  } else {
+  } else if (filteredNewElements.length === 1) {
     svgCanvas.selectOnly(filteredNewElements);
-
-    if (filteredNewElements.length > 1) {
-      svgCanvas.tempGroupSelectedElements();
-    }
+  } else {
+    // no selection until the temp group is created, to prevent the group type is not correct
+    svgCanvas.selectOnly(svgCanvas.tempGroupSelectedElements());
   }
 
   if (!batchCmd.isEmpty()) {


### PR DESCRIPTION
## Overview 

1. [fix(top-bar): disable path menu during selecting bitmap image](https://github.com/flux3dp/beam-studio-core/commit/8ea0b9baa1ceebc2168f92ba6d7f4c2abb42d6af) [[clickup]](https://app.clickup.com/t/86eqy9jx1)
2. [fix(top-bar): disable path menu for svg, dxf object](https://github.com/flux3dp/beam-studio-core/commit/180c02992fc273aea3e5dc2791e9f93a8dad1318)