### PR TITLE
Fix font func for rtl texts

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "delaunator": "^5.0.1",
     "eventemitter3": "^4.0.7",
     "exifr": "^7.1.3",
-    "fontkit": "EstherFu/fontkit",
+    "fontkit": "^2.0.4",
     "gl-matrix": "^3.3.0",
     "hammerjs": "^2.0.8",
     "immer": "^9.0.19",

--- a/src/web/app/actions/beambox/font-funcs.ts
+++ b/src/web/app/actions/beambox/font-funcs.ts
@@ -232,11 +232,11 @@ export const convertTextToPathByFontkit = (
         textPath.setAttribute('dominant-baseline', dominantBaseline);
         textPath.textContent = text;
       }
-      /* eslint-enable no-param-reassign */
 
       const run = fontObj.layout(text);
       const { glyphs, direction, positions } = run;
-      if (direction === 'rtl') {
+      const isRtl = direction === 'rtl';
+      if (isRtl) {
         glyphs.reverse();
         positions.reverse();
       }
@@ -248,8 +248,7 @@ export const convertTextToPathByFontkit = (
           const end = textPath.getEndPositionOfChar(i);
           if ([start.x, start.y, end.x, end.y].every((v) => v === 0)) return '';
           const rot = (textPath.getRotationOfChar(i) / 180) * Math.PI;
-          const x = Math.min(start.x, end.x);
-          const y = Math.min(start.y, end.y);
+          const { x, y } = isRtl ? end : start;
           char.codePoints.forEach((codePoint) => {
             i = codePoint > maxChar ? i + 2 : i + 1;
           });
@@ -269,7 +268,8 @@ export const convertTextToPathByFontkit = (
       const text = tspan.textContent;
       const run = fontObj.layout(text);
       const { glyphs, direction, positions } = run;
-      if (direction === 'rtl') {
+      const isRtl = direction === 'rtl';
+      if (isRtl) {
         glyphs.reverse();
         positions.reverse();
       }
@@ -279,8 +279,7 @@ export const convertTextToPathByFontkit = (
           const pos = positions[idx];
           const start = tspan.getStartPositionOfChar(i);
           const end = tspan.getEndPositionOfChar(i);
-          const x = Math.min(start.x, end.x);
-          const y = Math.min(start.y, end.y);
+          const { x, y } = isRtl ? end : start;
           char.codePoints.forEach((codePoint) => {
             i = codePoint > maxChar ? i + 2 : i + 1;
           });

--- a/src/web/app/actions/beambox/font-funcs.ts
+++ b/src/web/app/actions/beambox/font-funcs.ts
@@ -235,21 +235,30 @@ export const convertTextToPathByFontkit = (
       /* eslint-enable no-param-reassign */
 
       const run = fontObj.layout(text);
+      const { glyphs, direction, positions } = run;
+      if (direction === 'rtl') {
+        glyphs.reverse();
+        positions.reverse();
+      }
       let i = 0;
-      d += run.glyphs
-        .map((char) => {
+      d += glyphs
+        .map((char, idx) => {
+          const pos = positions[idx];
           const start = textPath.getStartPositionOfChar(i);
-          const end = textPath.getStartPositionOfChar(i);
+          const end = textPath.getEndPositionOfChar(i);
           if ([start.x, start.y, end.x, end.y].every((v) => v === 0)) return '';
           const rot = (textPath.getRotationOfChar(i) / 180) * Math.PI;
+          const x = Math.min(start.x, end.x);
+          const y = Math.min(start.y, end.y);
           char.codePoints.forEach((codePoint) => {
             i = codePoint > maxChar ? i + 2 : i + 1;
           });
           return char.path
+            .translate(pos.xOffset, pos.yOffset)
             .scale(sizeRatio, -sizeRatio)
             .translate(0, alignOffset)
             .rotate(rot)
-            .translate(start.x, start.y)
+            .translate(x, y)
             .toSVG();
         })
         .join('');
@@ -259,14 +268,27 @@ export const convertTextToPathByFontkit = (
     tspans.forEach((tspan) => {
       const text = tspan.textContent;
       const run = fontObj.layout(text);
+      const { glyphs, direction, positions } = run;
+      if (direction === 'rtl') {
+        glyphs.reverse();
+        positions.reverse();
+      }
       let i = 0;
-      d += run.glyphs
-        .map((char) => {
+      d += glyphs
+        .map((char, idx) => {
+          const pos = positions[idx];
           const start = tspan.getStartPositionOfChar(i);
+          const end = tspan.getEndPositionOfChar(i);
+          const x = Math.min(start.x, end.x);
+          const y = Math.min(start.y, end.y);
           char.codePoints.forEach((codePoint) => {
             i = codePoint > maxChar ? i + 2 : i + 1;
           });
-          return char.path.scale(sizeRatio, -sizeRatio).translate(start.x, start.y).toSVG();
+          return char.path
+            .translate(pos.xOffset, pos.yOffset)
+            .scale(sizeRatio, -sizeRatio)
+            .translate(x, y)
+            .toSVG();
         })
         .join('');
     });

--- a/yarn.lock
+++ b/yarn.lock
@@ -1316,12 +1316,12 @@
   dependencies:
     "@sinonjs/commons" "^3.0.0"
 
-"@swc/helpers@^0.5.0":
-  version "0.5.12"
-  resolved "https://registry.yarnpkg.com/@swc/helpers/-/helpers-0.5.12.tgz#37aaca95284019eb5d2207101249435659709f4b"
-  integrity sha512-KMZNXiGibsW9kvZAO1Pam2JPTDBm+KSHMMHWdsyI/1DbIZjT2A6Gy3hblVXUMEDvUAKq+e0vL0X0o54owWji7g==
+"@swc/helpers@^0.5.12":
+  version "0.5.15"
+  resolved "https://registry.yarnpkg.com/@swc/helpers/-/helpers-0.5.15.tgz#79efab344c5819ecf83a43f3f9f811fc84b516d7"
+  integrity sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==
   dependencies:
-    tslib "^2.4.0"
+    tslib "^2.8.0"
 
 "@szhsin/react-menu@^1.10.1":
   version "1.11.0"
@@ -3482,11 +3482,12 @@ follow-redirects@^1.15.6:
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.6.tgz#7f815c0cda4249c74ff09e95ef97c23b5fd0399b"
   integrity sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==
 
-fontkit@EstherFu/fontkit:
-  version "2.0.2"
-  resolved "https://codeload.github.com/EstherFu/fontkit/tar.gz/46bad634abd6c4265d52748a3ec4a30e676c955b"
+fontkit@^2.0.4:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/fontkit/-/fontkit-2.0.4.tgz#4765d664c68b49b5d6feb6bd1051ee49d8ec5ab0"
+  integrity sha512-syetQadaUEDNdxdugga9CpEYVaQIxOwk7GlwZWWZ19//qW4zE5bknOKeMBDYAASwnpaSHKJITRLMF9m1fp3s6g==
   dependencies:
-    "@swc/helpers" "^0.5.0"
+    "@swc/helpers" "^0.5.12"
     brotli "^1.3.2"
     clone "^2.1.2"
     dfa "^1.2.0"
@@ -6749,10 +6750,15 @@ tslib@^1.13.0, tslib@^1.8.1, tslib@^1.9.3:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
 
-tslib@^2.1.0, tslib@^2.4.0, tslib@^2.4.1, tslib@^2.5.0:
+tslib@^2.1.0, tslib@^2.4.1, tslib@^2.5.0:
   version "2.6.3"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.6.3.tgz#0438f810ad7a9edcde7a241c3d80db693c8cbfe0"
   integrity sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==
+
+tslib@^2.8.0:
+  version "2.8.1"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.8.1.tgz#612efe4ed235d567e8aba5f2a5fab70280ade83f"
+  integrity sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==
 
 tslint@^6.1.3:
   version "6.1.3"


### PR DESCRIPTION
Fix fontkit text to path for rtl text by: [clickup](https://app.clickup.com/t/86eqzmhen)
1. Getting the start position from `getStartPositionOfChar` or `getEndPositionOfChar` according to direction.
2. Reverse glyph
3. fix some mark position by `run.position`
Known issue:
some mac font may still have offseted mark