### PR TITLE
feat(material-test-generator): set speed of textsetting to 1000

### DIFF
--- a/src/web/app/components/dialogs/MaterialTestGeneratorPanel/TextSetting.ts
+++ b/src/web/app/components/dialogs/MaterialTestGeneratorPanel/TextSetting.ts
@@ -1,3 +1,6 @@
+import { promarkModels } from 'app/actions/beambox/constant';
+import { WorkAreaModel } from 'app/constants/workarea-constants';
+
 export interface TextSetting {
   select: { value: string; label: string };
   power: number;
@@ -6,8 +9,8 @@ export interface TextSetting {
 
 export const textParams = ['power', 'speed'] as const;
 
-export const textSetting = (): TextSetting => ({
+export const getTextSetting = (workarea: WorkAreaModel): TextSetting => ({
   select: { value: 'custom', label: 'Custom' },
   power: 15,
-  speed: 20,
+  speed: promarkModels.has(workarea) ? 1000 : 20,
 });

--- a/src/web/app/components/dialogs/MaterialTestGeneratorPanel/index.tsx
+++ b/src/web/app/components/dialogs/MaterialTestGeneratorPanel/index.tsx
@@ -27,7 +27,7 @@ import WorkAreaInfo from './WorkAreaInfo';
 import TableSettingForm from './TableSettingForm';
 import BlockSettingForm from './BlockSettingForm';
 import { getTableSetting } from './TableSetting';
-import { textSetting as defaultTextSetting } from './TextSetting';
+import { getTextSetting } from './TextSetting';
 import { BlockInfo, BlockSetting, getBlockSetting } from './BlockSetting';
 import generateSvgInfo, { SvgInfo } from './generateSvgInfo';
 import TextSettingForm from './TextSettingForm';
@@ -80,7 +80,7 @@ const MaterialTestGeneratorPanel = ({ onClose }: Props): JSX.Element => {
   const [blockOption, setBlockOption] = useState<'cut' | 'engrave'>('cut');
   const [tableSetting, setTableSetting] = useState(getTableSetting(workarea, { laserType }));
   const [blockSetting, setBlockSetting] = useState(getBlockSetting);
-  const [textSetting, setTextSetting] = useState(defaultTextSetting);
+  const [textSetting, setTextSetting] = useState(getTextSetting(workarea));
   const blockOptions = [
     { label: t.material_test_generator.cut, value: 'cut' },
     { label: t.material_test_generator.engrave, value: 'engrave' },


### PR DESCRIPTION
## Overview

1. set speed of text setting to 1000 if using promark models