### PR TITLE
Promark feedback

### DIFF
--- a/src/web/app/components/dialogs/promark/PromarkSettings.spec.tsx
+++ b/src/web/app/components/dialogs/promark/PromarkSettings.spec.tsx
@@ -152,8 +152,8 @@ describe('test PromarkSettings', () => {
     expect(mockGenerateCalibrationTaskString).toBeCalledTimes(1);
     expect(mockGenerateCalibrationTaskString).toBeCalledWith({
       width: 150,
-      power: 100,
-      speed: 350,
+      power: 50,
+      speed: 1000,
     });
     expect(mockLoadTaskToSwiftray).toBeCalledTimes(1);
     expect(mockLoadTaskToSwiftray).toBeCalledWith('task', 'fpm1');

--- a/src/web/app/components/dialogs/promark/PromarkSettings.tsx
+++ b/src/web/app/components/dialogs/promark/PromarkSettings.tsx
@@ -46,7 +46,7 @@ const PromarkSettings = ({ device, initData, onClose }: Props): JSX.Element => {
   const [galvoParameters, setGalvoCorrection] = useState<GalvoParameters>(
     initData.galvoParameters || defaultGalvoParameters
   );
-  const [parameters, setParameters] = useState<MarkParameters>({ power: 100, speed: 350 });
+  const [parameters, setParameters] = useState<MarkParameters>({ power: 50, speed: 1000 });
   const { power, speed } = parameters;
   const { width } = useMemo(() => getWorkarea(model), [model]);
   const [isPreviewing, setIsPreviewing] = useState(false);

--- a/src/web/app/components/dialogs/promark/ZAxisAdjustment.tsx
+++ b/src/web/app/components/dialogs/promark/ZAxisAdjustment.tsx
@@ -38,7 +38,7 @@ export const ZAxisAdjustment = ({ device, onClose }: Props): JSX.Element => {
   const [zAxis, setZAxis] = useState(1);
   const [isPreviewing, setIsPreviewing] = useState(false);
   const [isMoving, setIsMoving] = useState(false);
-  const [parameters, setParameters] = useState<MarkParameters>({ power: 100, speed: 350 });
+  const [parameters, setParameters] = useState<MarkParameters>({ power: 50, speed: 1000 });
   const previewTask = useRef<string>('');
   const markTask = useRef<string>('');
   const movingTimeout = useRef<NodeJS.Timeout>();

--- a/src/web/app/contexts/MonitorContext.tsx
+++ b/src/web/app/contexts/MonitorContext.tsx
@@ -548,10 +548,14 @@ export class MonitorContextProvider extends React.Component<Props, State> {
   enterWorkingMode = async (task?: { taskImageURL: string; taskTime: number }): Promise<void> => {
     if (!task) {
       const taskInfo = await this.getWorkingTaskInfo();
-      const { imageBlob, taskTime } = this.getTaskInfo(taskInfo);
-      let { taskImageURL } = this.state;
+      const { imageBlob, taskTime: newTaskTime } = this.getTaskInfo(taskInfo);
+      let { taskImageURL, taskTime } = this.state;
       if (imageBlob) {
         taskImageURL = URL.createObjectURL(imageBlob);
+      }
+      if (newTaskTime) {
+        // Ignore 0 task time after swiftray restart
+        taskTime = newTaskTime;
       }
       this.setState({
         mode: Mode.WORKING,

--- a/src/web/app/views/beambox/Right-Panels/ConfigPanel/FillSettingModal.module.scss
+++ b/src/web/app/views/beambox/Right-Panels/ConfigPanel/FillSettingModal.module.scss
@@ -21,5 +21,5 @@
 .hint {
   font-size: 14px;
   color: #ababab;
-  margin-left: 7px;
+  line-height: 1.2;
 }

--- a/src/web/app/views/beambox/Right-Panels/ConfigPanel/FillSettingModal.tsx
+++ b/src/web/app/views/beambox/Right-Panels/ConfigPanel/FillSettingModal.tsx
@@ -1,6 +1,5 @@
 import React, { useContext, useState } from 'react';
-import { Modal, Switch, Tooltip } from 'antd';
-import { QuestionCircleOutlined } from '@ant-design/icons';
+import { Modal, Switch } from 'antd';
 
 import eventEmitterFactory from 'helpers/eventEmitterFactory';
 import UnitInput from 'app/widgets/Unit-Input-v2';
@@ -65,15 +64,9 @@ const FillSettingModal = ({ onClose }: Props): JSX.Element => {
       onCancel={onClose}
       cancelText={tGlobal.cancel}
       okText={tGlobal.save}
-      title={
-        <div>
-          {t.fill_setting}
-          <Tooltip title={t.filled_path_only}>
-            <QuestionCircleOutlined className={styles.hint} />
-          </Tooltip>
-        </div>
-      }
+      title={t.fill_setting}
     >
+      <div className={styles.hint}>{t.filled_path_only}</div>
       <div className={styles.container}>
         <div>
           <span>{t.fill_interval}</span>

--- a/src/web/app/views/beambox/Right-Panels/ConfigPanel/__snapshots__/FillSettingModal.spec.tsx.snap
+++ b/src/web/app/views/beambox/Right-Panels/ConfigPanel/__snapshots__/FillSettingModal.spec.tsx.snap
@@ -66,36 +66,17 @@ exports[`test FillSettingModal should render correctly 1`] = `
                 class="ant-modal-title"
                 id="test-id"
               >
-                <div>
-                  Fill Setting
-                  <span
-                    aria-label="question-circle"
-                    class="anticon anticon-question-circle hint"
-                    role="img"
-                  >
-                    <svg
-                      aria-hidden="true"
-                      data-icon="question-circle"
-                      fill="currentColor"
-                      focusable="false"
-                      height="1em"
-                      viewBox="64 64 896 896"
-                      width="1em"
-                    >
-                      <path
-                        d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm0 820c-205.4 0-372-166.6-372-372s166.6-372 372-372 372 166.6 372 372-166.6 372-372 372z"
-                      />
-                      <path
-                        d="M623.6 316.7C593.6 290.4 554 276 512 276s-81.6 14.5-111.6 40.7C369.2 344 352 380.7 352 420v7.6c0 4.4 3.6 8 8 8h48c4.4 0 8-3.6 8-8V420c0-44.1 43.1-80 96-80s96 35.9 96 80c0 31.1-22 59.6-56.1 72.7-21.2 8.1-39.2 22.3-52.1 40.9-13.1 19-19.9 41.8-19.9 64.9V620c0 4.4 3.6 8 8 8h48c4.4 0 8-3.6 8-8v-22.7a48.3 48.3 0 0130.9-44.8c59-22.7 97.1-74.7 97.1-132.5.1-39.3-17.1-76-48.3-103.3zM472 732a40 40 0 1080 0 40 40 0 10-80 0z"
-                      />
-                    </svg>
-                  </span>
-                </div>
+                Fill Setting
               </div>
             </div>
             <div
               class="ant-modal-body"
             >
+              <div
+                class="hint"
+              >
+                For fill paths only
+              </div>
               <div
                 class="container"
               >

--- a/src/web/helpers/layer/layer-config-helper.spec.ts
+++ b/src/web/helpers/layer/layer-config-helper.spec.ts
@@ -91,6 +91,12 @@ const defaultLaserConfigs = {
   dottingTime: { value: 100 },
 };
 
+// Boolean without initLayerConfig will be false
+// Update expected value when initLayerConfig is called
+const trueConfigs = {
+  biDirectional: { value: true },
+};
+
 const defaultMultiValueLaserConfigs = {
   speed: { value: 20, hasMultiValue: false },
   printingSpeed: { value: 60, hasMultiValue: false },
@@ -149,7 +155,7 @@ describe('test layer-config-helper', () => {
 
   test('initLayerConfig', () => {
     initLayerConfig('layer 1');
-    expect(getLayerConfig('layer 1')).toEqual(defaultLaserConfigs);
+    expect(getLayerConfig('layer 1')).toEqual({ ...defaultLaserConfigs, ...trueConfigs });
   });
 
   test('initLayerConfig with module', () => {
@@ -158,7 +164,11 @@ describe('test layer-config-helper', () => {
       return undefined;
     });
     initLayerConfig('layer 1');
-    expect(getLayerConfig('layer 1')).toEqual({ ...defaultLaserConfigs, module: { value: 1 } });
+    expect(getLayerConfig('layer 1')).toEqual({
+      ...defaultLaserConfigs,
+      ...trueConfigs,
+      module: { value: 1 },
+    });
   });
 
   test('write zstep data', () => {

--- a/src/web/helpers/layer/layer-config-helper.ts
+++ b/src/web/helpers/layer/layer-config-helper.ts
@@ -104,6 +104,7 @@ export const baseConfig: Partial<ConfigKeyTypeMap> = {
   // promark parameters
   fillInterval: 0.01,
   fillAngle: 0,
+  biDirectional: true,
   frequency: 27,
   pulseWidth: 100,
   dottingTime: 100,


### PR DESCRIPTION
1. Fill setting modal 說明不用 hover，直接顯示
2. Bi-directional 改預設為開
3. Promark 設定、Z 軸移動，打標的預設功率改為功率 50% , 速度 1000mm/s
5. Swiftray 重開後，再次送工作，預估時長為 0