### PR TITLE
Fix shortcuts

### DIFF
--- a/src/web/app/components/ImageEditPanel/index.tsx
+++ b/src/web/app/components/ImageEditPanel/index.tsx
@@ -48,6 +48,8 @@ const EXPORTING = 1;
 
 const IMAGE_PADDING = 30;
 
+const scope = 'image-edit-panel';
+
 function ImageEditPanel({ src, image, onClose }: Props): JSX.Element {
   const {
     beambox: { photo_edit_panel: langPhoto },
@@ -325,6 +327,7 @@ function ImageEditPanel({ src, image, onClose }: Props): JSX.Element {
   }, [progress, imageSize, imageRef.current?.useImageStatus, forceUpdate]);
 
   useEffect(() => {
+    shortcuts.enterScope(scope);
     const initialize = async () => {
       const { clientHeight, clientWidth } = divRef.current;
       const {
@@ -376,20 +379,22 @@ function ImageEditPanel({ src, image, onClose }: Props): JSX.Element {
 
     return () => {
       observer.disconnect();
+      shortcuts.enterScope('');
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   useEffect(() => {
     const subscribedShortcuts = [
-      shortcuts.on(['Escape'], onClose, { isBlocking: true }),
-      shortcuts.on(['Fnkey+z'], handleHistoryChange('undo'), { isBlocking: true }),
-      shortcuts.on(['Shift+Fnkey+z'], handleHistoryChange('redo'), { isBlocking: true }),
+      shortcuts.on(['Escape'], onClose, { isBlocking: true, scope }),
+      shortcuts.on(['Fnkey+z'], handleHistoryChange('undo'), { isBlocking: true, scope }),
+      shortcuts.on(['Shift+Fnkey+z'], handleHistoryChange('redo'), { isBlocking: true, scope }),
       shortcuts.on(['Fnkey-+', 'Fnkey-='], () => handleZoomByScale(1.2), {
         isBlocking: true,
         splitKey: '-',
+        scope,
       }),
-      shortcuts.on(['Fnkey+-'], () => handleZoomByScale(0.8), { isBlocking: true }),
+      shortcuts.on(['Fnkey+-'], () => handleZoomByScale(0.8), { isBlocking: true, scope }),
     ];
 
     return () => {

--- a/src/web/app/components/dialogs/myCloud/GridFile.tsx
+++ b/src/web/app/components/dialogs/myCloud/GridFile.tsx
@@ -149,6 +149,7 @@ const GridFile = ({ file }: Props): JSX.Element => {
             }}
             onBlur={onChangeName}
             onPressEnter={onChangeName}
+            onKeyDown={(e) => e.stopPropagation()}
             status={error ? 'error' : undefined}
             maxLength={255}
           />

--- a/src/web/app/widgets/UnitInput.tsx
+++ b/src/web/app/widgets/UnitInput.tsx
@@ -113,7 +113,9 @@ const UnitInput = forwardRef<HTMLInputElement, Props>(
             onStep={handleStep}
             formatter={formatter}
             parser={parser}
-            onKeyDown={(e) => e.stopPropagation()}
+            onKeyDown={(e) => {
+              if (e.key !== 'Enter') e.stopPropagation();
+            }}
           />
           {unit && <span className={styles.unit}>{unit}</span>}
         </ConfigProvider>

--- a/src/web/app/widgets/UnitInput.tsx
+++ b/src/web/app/widgets/UnitInput.tsx
@@ -113,6 +113,7 @@ const UnitInput = forwardRef<HTMLInputElement, Props>(
             onStep={handleStep}
             formatter={formatter}
             parser={parser}
+            onKeyDown={(e) => e.stopPropagation()}
           />
           {unit && <span className={styles.unit}>{unit}</span>}
         </ConfigProvider>


### PR DESCRIPTION
- 輸入框無法使用左右鍵移動、無法刪除
快捷鍵 default 設定會 preventDefault
先在 UnitInput、雲端檔案名編輯時加上 stopPropagation，避開快捷鍵
（可能仍有部分 input 會和快捷鍵設定衝突

- 圖片進階編輯時，按刪除鍵會刪除圖片；按 E 會跳出元素面板
除了特別設定的快捷鍵，其餘快捷鍵仍會生效
暫時給圖片進階編輯加 scope，禁用其餘快捷鍵
（待確認做法&是否要保留部分快捷鍵