### PR TITLE
Update shortcut scopes

### DIFF
--- a/src/web/app/actions/beambox/menuActions.ts
+++ b/src/web/app/actions/beambox/menuActions.ts
@@ -16,6 +16,7 @@ import isWeb from 'helpers/is-web';
 import imageEdit from 'helpers/image-edit';
 import MessageCaller, { MessageLevel } from 'app/actions/message-caller';
 import OutputError from 'helpers/output-error';
+import shortcuts from 'helpers/shortcuts';
 import Tutorials from 'app/actions/beambox/tutorials';
 import viewMenu from 'helpers/menubar/view';
 import workareaManager from 'app/svgedit/workarea';
@@ -203,8 +204,12 @@ export default {
     if (isWeb()) Dialog.forceLoginWrapper(() => ExportFuncs.exportFcode());
     else ExportFuncs.exportFcode();
   },
-  UNDO: historyUtils.undo,
-  REDO: historyUtils.redo,
+  UNDO: (): void => {
+    if (shortcuts.isInBaseScope()) historyUtils.undo();
+  },
+  REDO: (): void => {
+    if (shortcuts.isInBaseScope()) historyUtils.redo();
+  },
   GROUP: (): Promise<void> => svgCanvas.groupSelectedElements(),
   UNGROUP: (): Promise<void> => svgCanvas.ungroupSelectedElement(),
   DELETE: (): Promise<void> => svgEditor.deleteSelected(),

--- a/src/web/app/actions/beambox/svg-editor.ts
+++ b/src/web/app/actions/beambox/svg-editor.ts
@@ -2051,7 +2051,13 @@ const svgEditor = (window['svgEditor'] = (function () {
       }
     };
     editor.cutSelected = cutSelected;
-    document.addEventListener('cut', cutSelected, false);
+    document.addEventListener(
+      'cut',
+      () => {
+        if (Shortcuts.isInBaseScope()) cutSelected();
+      },
+      false
+    );
 
     var copySelected = function () {
       // disabled when focusing input element
@@ -2063,10 +2069,18 @@ const svgEditor = (window['svgEditor'] = (function () {
       }
     };
     editor.copySelected = copySelected;
-    document.addEventListener('copy', copySelected, false);
+    document.addEventListener(
+      'copy',
+      () => {
+        if (Shortcuts.isInBaseScope()) copySelected();
+      },
+      false
+    );
 
     // handle paste
     document.addEventListener('paste', async (e) => {
+      // disabled when not in base scope
+      if (!Shortcuts.isInBaseScope()) return;
       // disabled when focusing input element
       if (document.activeElement.tagName.toLowerCase() === 'input') {
         return;

--- a/src/web/app/actions/dialog-caller.tsx
+++ b/src/web/app/actions/dialog-caller.tsx
@@ -514,13 +514,10 @@ export default {
   showBoxGen: (onClose: () => void = () => {}): void => {
     if (isIdExist('box-gen')) return;
 
-    shortcuts.pauseAll();
-
     addDialogComponent(
       'box-gen',
       <Boxgen
         onClose={() => {
-          shortcuts.initialize();
           onClose();
           popDialogById('box-gen');
         }}

--- a/src/web/app/components/ImageEditPanel/index.tsx
+++ b/src/web/app/components/ImageEditPanel/index.tsx
@@ -264,7 +264,6 @@ function ImageEditPanel({ src, image, onClose }: Props): JSX.Element {
     // depends useImageStatus to force re-render
   }, [progress, imageSize, imageRef.current?.useImageStatus, forceUpdate]);
 
-  useNewShortcutsScope();
   useEffect(() => {
     const initialize = async () => {
       const { clientHeight, clientWidth } = divRef.current;
@@ -321,6 +320,7 @@ function ImageEditPanel({ src, image, onClose }: Props): JSX.Element {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
+  useNewShortcutsScope();
   useEffect(() => {
     const subscribedShortcuts = [
       shortcuts.on(['Escape'], onClose, { isBlocking: true, scope }),

--- a/src/web/app/components/ImageEditPanel/index.tsx
+++ b/src/web/app/components/ImageEditPanel/index.tsx
@@ -18,6 +18,7 @@ import shortcuts from 'helpers/shortcuts';
 import progressCaller from 'app/actions/progress-caller';
 import FullWindowPanel from 'app/widgets/FullWindowPanel/FullWindowPanel';
 
+import useNewShortcutsScope from 'helpers/hooks/useNewShortcutsScope';
 import useKonvaCanvas from 'helpers/hooks/konva/useKonvaCanvas';
 import useForceUpdate from 'helpers/use-force-update';
 import { useKeyDown } from 'helpers/hooks/useKeyDown';
@@ -263,8 +264,8 @@ function ImageEditPanel({ src, image, onClose }: Props): JSX.Element {
     // depends useImageStatus to force re-render
   }, [progress, imageSize, imageRef.current?.useImageStatus, forceUpdate]);
 
+  useNewShortcutsScope();
   useEffect(() => {
-    shortcuts.enterScope(scope);
     const initialize = async () => {
       const { clientHeight, clientWidth } = divRef.current;
       const {
@@ -316,7 +317,6 @@ function ImageEditPanel({ src, image, onClose }: Props): JSX.Element {
 
     return () => {
       observer.disconnect();
-      shortcuts.enterScope('');
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);

--- a/src/web/app/components/boxgen/Boxgen.tsx
+++ b/src/web/app/components/boxgen/Boxgen.tsx
@@ -6,6 +6,7 @@ import FullWindowPanel from 'app/widgets/FullWindowPanel/FullWindowPanel';
 import Header from 'app/widgets/FullWindowPanel/Header';
 import Sider from 'app/widgets/FullWindowPanel/Sider';
 import useI18n from 'helpers/useI18n';
+import useNewShortcutsScope from 'helpers/hooks/useNewShortcutsScope';
 import { BoxgenProvider } from 'app/contexts/BoxgenContext';
 
 import BoxCanvas from './BoxCanvas';
@@ -15,6 +16,7 @@ import ExportButton from './ExportButton';
 import styles from './Boxgen.module.scss';
 
 const Boxgen = ({ onClose }: { onClose?: () => void }): JSX.Element => {
+  useNewShortcutsScope();
   const lang = useI18n();
   const tBoxgen = lang.boxgen;
 

--- a/src/web/helpers/hooks/useNewShortcutsScope.ts
+++ b/src/web/helpers/hooks/useNewShortcutsScope.ts
@@ -6,7 +6,7 @@ const useNewShortcutsScope = (): void => {
   useEffect(() => {
     const exit = shortcuts.enterScope();
     return () => exit();
-  });
+  }, []);
 };
 
 export default useNewShortcutsScope;

--- a/src/web/helpers/hooks/useNewShortcutsScope.ts
+++ b/src/web/helpers/hooks/useNewShortcutsScope.ts
@@ -1,0 +1,12 @@
+import { useEffect } from 'react';
+
+import shortcuts from 'helpers/shortcuts';
+
+const useNewShortcutsScope = (): void => {
+  useEffect(() => {
+    const exit = shortcuts.enterScope();
+    return () => exit();
+  });
+};
+
+export default useNewShortcutsScope;

--- a/src/web/helpers/shortcuts.ts
+++ b/src/web/helpers/shortcuts.ts
@@ -164,7 +164,7 @@ export default {
     const newEvents: Array<ShortcutEvent> = [];
     eventScopes.push(newEvents);
     const exitScope = () => {
-      // use splice instead of pop to in case another scope is entered before this scope is exited
+      // use splice instead of pop to in case another scope is entered before exitted
       const idx = eventScopes.indexOf(newEvents);
       if (idx >= 0) {
         eventScopes.splice(idx, 1);


### PR DESCRIPTION
1. change shortcut scope structure to array of array (can also be key -> array pairs but I am afraid of scope new collision)
2. Block editor events from electron accelerator (undo, redo, cut, copy, paste) when not in base scope